### PR TITLE
Hotfix

### DIFF
--- a/lib/components/AdapterEndpoint/AdapterEndpoint.types.ts
+++ b/lib/components/AdapterEndpoint/AdapterEndpoint.types.ts
@@ -1,0 +1,99 @@
+import type { AxiosRequestConfig } from "axios";
+
+type status = "init" | "connected" | "error";
+
+interface AdapterEndpoint_t<T = NodeJSON> {
+    /**
+     *  Recursive Nested dictionary structure representing the adapter Param Tree. Should be read only
+     * from this interface
+     */
+    data: Readonly<T>;
+
+    /**
+     * Dictionary structure containing the adapter Metadata, if its implimented by the adapter
+     */
+    metadata: Readonly<NodeJSON>;
+    /**
+     *  Any Errors that occur during http methods or otherwise will be accessible here
+     */
+    error: null | Error;
+    /**
+     * State of the http client connection to the adapter. 
+     * If true, the AdapterEndpoint is awaiting a response from the adapter.
+     */
+    loading: boolean;
+
+    /**
+     * Flag token that will change whenever the data has changed, to alert WithEndpoint components
+     */
+    updateFlag: symbol;
+
+    /**
+     * Connection status for the AdapterEndpoint.
+     */
+    status: status;
+    /**
+     * Async http GET method. Request the provided value(s) from the parameter tree.
+     * It is worth noting that this method does NOT automatically merge the response into the Endpoint.Data object.
+     * @param {string} [param_path=""] - the path of the data desired. defaults to an Empty String to get the entire param tree
+     * @param {boolean} [get_metadata] - set to true to request Metadata. Defaults to false
+     * @returns An Async promise, that when resolved will return the data within the HTTP response
+     */
+    get: <T = NodeJSON>(param_path?: string, config?: getConfig) => Promise<T>;
+    /**
+     * Async http PUT method. Modify the data in the param tree at the provided path
+     * It is worth noting that this method does NOT automatically merge the response into the Endpoint.Data object.
+     * @param {NodeJSON} data - The data, with a key, that you wish to PUT to the Param Tree
+     * @param {string} param_path - the path you want to PUT to. Defaults to an empty string for a top level PUT
+     * @returns An Async promise, that when resolved will return the data within the HTTP response
+     */
+    put: (data: NodeJSON, param_path?: string) => Promise<NodeJSON>;
+
+    /**
+     * Async http POST method. Not often implemented by Adapters, but potentially used to post data
+     * files or some other new data to the adapter
+     * @param {NodeJSON} data - The data, with a key, that you wish to POST to the adapter
+     * @param param_path  - the path you want to POST to. defaults to an empty string, for a top level POST
+     * @returns An Async promise, that when resolved will return the data within the HTTP response
+     */
+    post: (data: NodeJSON, param_path?: string) => Promise<NodeJSON>;
+
+    /**
+     * Async http DELETE method. Renamed because 'delete' is a reserved word in javascript. Not often
+     * implemented by adapters.
+     * @param param_path the path to the data you want to DELETE. Defaults to an empty string
+     * @returns An Async promise, that when resolved will return the data within the HTTP response
+     */
+    remove: (param_path?: string) => Promise<NodeJSON>;
+    /**
+     * A method to automatically perform a top level GET request and refresh the AdapterEndpoint's current view of the data
+     * @returns 
+     */
+    refreshData: () => void;
+    /**
+     * A method to merge one chunk of (potentially nested) data into the AdapterEndpoint's current view of the data,
+     * to update the data without having to GET from the entire adapter
+     * @param {NodeJSON} newData - The new data to be merged in
+     * @param {string} param_path - the location that data within the ParamTree to merge it
+     * @returns 
+     */
+    mergeData: (newData: NodeJSON, param_path: string) => void;
+
+}
+
+/**
+ * Defines allowed values for JSON dict.
+ */
+type JSON = string | number | boolean | null | undefined | JSON[] | NodeJSON;
+
+/**
+ * JSON Dict, defines key/value pairing.
+ */
+type NodeJSON = {[key:string]: JSON};
+
+interface getConfig {
+    wants_metadata?: boolean;
+    responseType?: AxiosRequestConfig['responseType'];
+}
+
+export type { AdapterEndpoint_t, JSON, NodeJSON, getConfig, status};

--- a/lib/components/OdinLiveView/index.tsx
+++ b/lib/components/OdinLiveView/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { AdapterEndpoint_t, NodeJSON} from '../../helpers/types';
+import type { AdapterEndpoint_t, NodeJSON} from '../AdapterEndpoint';
 import { getValueFromPath } from '../../helpers/utils';
 
 import React, { useCallback, useEffect, useState, useRef } from 'react';

--- a/lib/components/OdinLiveView/index.tsx
+++ b/lib/components/OdinLiveView/index.tsx
@@ -9,7 +9,7 @@ import defaultImg from '../../assets/odin.png';
 import { Row, Col, Button, Dropdown, ButtonGroup, OverlayTriggerProps } from 'react-bootstrap';
 import { OverlayTrigger, Popover, Card} from 'react-bootstrap';
 
-import { ZoomIn, ZoomOut, PauseFill, PlayFill, List } from 'react-bootstrap-icons';
+import { ZoomIn, ZoomOut, PauseFill, PlayFill, List, ArrowsAngleContract, ArrowsAngleExpand } from 'react-bootstrap-icons';
 
 import style from './styles.module.css';
 import { WithEndpoint } from '../WithEndpoint';
@@ -33,8 +33,6 @@ interface ZoomableImageProps {
 
 interface LiveViewParam extends NodeJSON {
     frame: {
-        dtype: string;
-        shape: number[];
         frame_num: number;
     }
     colormap_options: Record<string, string>;
@@ -60,15 +58,22 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = (props) => {
     const {src, caption, additional_hover } = props;
 
     const [dims, setDims] = useState([1024, 1024]);
+    const [divWidth, setDivWidth] = useState(500);
     const [dragStart, setDragStart] = useState([0, 0]);
     const [scale, setScale] = useState(100);
     // const [overlayVisible, setVisible] = useState<CSSProperties["visibility"]>("hidden");
 
     const imgRef = useRef<HTMLImageElement>(null);
 
+    useEffect(() => {
+        setScale(getFitScale());
+    }, [imgRef.current, dims[0]]);
+
     const onLoad: React.ReactEventHandler<HTMLImageElement> = (event) => {
         const target = event.target as HTMLImageElement;
+        const parent = target.parentElement as HTMLDivElement;
         setDims([target.naturalWidth, target.naturalHeight]);
+        setDivWidth(parent.clientWidth);
     }
 
     const onMouseDown: React.MouseEventHandler<HTMLImageElement> = (event) => {
@@ -92,9 +97,14 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = (props) => {
         }
     }
 
+    const getFitScale = () => {
+        // gets the scale we need to apply to the image to make it fit the container its in
+        return (divWidth / dims[0]) * 100;
+    }
+
     return (
         <figure className={style.figure}>
-            <div className={style.liveImg}>
+            <div className={style.liveImg} style={{aspectRatio: `${dims[0]} / ${dims[1]}`}}>
                 <img src={src} onLoad={onLoad} width={dims[0]*(scale/100)}
                      onMouseMove={onDrag} onMouseDown={onMouseDown} ref={imgRef}
                      draggable={false}/>
@@ -108,9 +118,14 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = (props) => {
                 <Button title="Zoom Out" variant="secondary" onClick={() => setScale(oldScale => Math.max(oldScale-10, 10 ))}>
                     <ZoomOut/>
                 </Button>
-                <Button title='Reset Zoom' variant='secondary' onClick={() => setScale(100)}>{`${scale}%`}</Button>
+                <Button title='Reset Zoom' variant='secondary' onClick={() => setScale(getFitScale())}>
+                    <ArrowsAngleContract/>
+                </Button>
+                <Button title='Full Scale' variant='secondary' onClick={() => setScale(100)}>
+                    <ArrowsAngleExpand/>
+                </Button>
                 <Button title="Zoom In" variant="secondary" onClick={() => setScale(oldScale => oldScale+10)}>
-                <ZoomIn/>
+                    <ZoomIn/>
                 </Button>
                 </ButtonGroup>
                 </Col>

--- a/lib/components/OdinLiveView/styles.module.css
+++ b/lib/components/OdinLiveView/styles.module.css
@@ -1,6 +1,5 @@
 .liveImg {
     max-width: 100%;
-    aspect-ratio: 1 / 1;
     overflow-x: hidden;
     overflow-y: hidden;
     cursor: grab;
@@ -29,6 +28,8 @@
 
 .figure {
     position: relative;
+    text-align: center;
+    align-content: center;
 }
 
 .figure:hover .zoomOverlay {

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
-import { AdapterEndpoint_t, isParamNode, JSON } from "../../helpers/types";
+import type { AdapterEndpoint_t, JSON } from "../AdapterEndpoint";
+import { isParamNode } from "../AdapterEndpoint";
 import { useError } from "../OdinErrorContext";
 import { getValueFromPath } from "../../helpers/utils";
 import { isEqual } from 'lodash';
@@ -181,15 +182,17 @@ export const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =
                 for(const _ in endpoint.metadata) return true;
                 return false;
             }
-            if(endpointLoaded()){
+            if(endpointLoaded() && endpoint.status != "error"){
                 let data = getValueFromPath<ComponentProps['value']>(endpoint.metadata, fullpath);
+                let val: JSON;
+                const tmp_metadata: metadata_t = {readOnly: false, min: min, max: max};
                 if(isParamNode(data) && "writeable" in data){ //metadata found
-                    const tmp_metadata: metadata_t = {readOnly: ! (data['writeable'] as boolean)};
+                    tmp_metadata.readOnly = !(data['writeable'] as boolean);
                     tmp_metadata.min = min ?? (data.min ? data.min as number : undefined);
                     tmp_metadata.max = max ?? (data.max ? data.max as number : undefined);
 
-                    setMetadata(tmp_metadata);
-                    setEndpointValue(value ?? data.value as ComponentProps["value"]);
+                    // setMetadata(tmp_metadata);
+                    val = value ?? data.value as ComponentProps["value"];
 
                     switch(data.type as string){
                         case "int":
@@ -217,9 +220,8 @@ export const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =
 
                 }else{
                     data = getValueFromPath<ComponentProps['value']>(endpoint.data, fullpath);
-                    console.log("Adapter has not implemented Metadata for", fullpath);
-                    console.log(fullpath, data);
-                    setEndpointValue(value ?? data as ComponentProps["value"]);
+                    console.debug("Adapter has not implemented Metadata for", fullpath);
+                    val = value ?? data as ComponentProps["value"];
                     const data_type = (value == null ? typeof data : typeof value);
                     switch(data_type){
                         case "bigint":
@@ -241,22 +243,20 @@ export const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =
                             break;
                         case "function":
                         case "symbol":
-                        case "undefined":
+                        case "undefined": {
                             console.error("Something went wrong getting the typeof Data: ", data, typeof data);
+                            const error = new Error(`Invalid Data type ${data_type} for path ${fullpath}. If Undefined, check fullPath is correct`);
+                            ErrCTX.setError(error);
                             break;
+                        }
                         case "boolean":
                         case "string":
                             setType(data_type);
-
-                            
                     }
-
-                    if(min != null || max!= null){
-                        const tmp_metadata: metadata_t = {readOnly: false, min: min, max: max};
-                        setMetadata(tmp_metadata);
-                    }
-                    
                 }
+                setEndpointValue(val);
+                setComponentValue(val);
+                setMetadata(tmp_metadata);
             }
         }, [endpoint.metadata]);
 
@@ -328,7 +328,8 @@ export const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =
             sendRequest(eventKey);
         }
 
-        const onClickHandler = (_event: React.MouseEvent) => {
+        const onClickHandler = (event: React.MouseEvent) => {
+            console.debug(fullpath, event);
             const curComponent = component.current!;
             let val: ComponentProps['value'];
             if(value != null){

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,6 +1,6 @@
-export { useAdapterEndpoint } from './components/AdapterEndpoint'
-export { WithEndpoint } from './components/WithEndpoint'
-export { TitleCard } from './components/TitleCard'
+export { useAdapterEndpoint } from './components/AdapterEndpoint';
+export { WithEndpoint } from './components/WithEndpoint';
+export { TitleCard } from './components/TitleCard';
 export { OdinApp } from './components/OdinApp';
 export { OdinGraph } from './components/OdinGraph';
 export {OdinTable, OdinTableRow } from './components/OdinTable';
@@ -8,4 +8,7 @@ export {OdinEventLog} from './components/OdinEventLog';
 export {OdinErrorContext, OdinErrorOutlet, useError } from './components/OdinErrorContext';
 export {OdinDoubleSlider} from './components/OdinDoubleSlider';
 export { OdinLiveView, ZoomableImage } from './components/OdinLiveView';
-export type { ParamTree, Log, AdapterEndpoint_t, GraphData, Axis } from './helpers/types';
+export type { Log, GraphData, Axis } from './helpers/types';
+
+export type { AdapterEndpoint_t, NodeJSON as ParamTree } from "./components/AdapterEndpoint";
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odin-react",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.3",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     react(),
     // externalizeDeps(),
     libInjectCss(),
-    dts({ include: ['lib'] }),
+    dts({ tsconfigPath: './tsconfig-build.json', bundleTypes: true }),
     libAssetsPlugin()
     
   ],
@@ -29,11 +29,12 @@ export default defineConfig({
       formats: ['es']
     },
     rollupOptions: {
-      external: ['react', 'react/jsx-runtime', "bootstrap", "react-bootstrap", "plotly.js", "react-plotly.js", "react-bootstrap-icons"],
+      external: ['react', 'react/jsx-runtime', "bootstrap", "react-bootstrap", 
+        "plotly.js", "react-plotly.js", "react-bootstrap-icons", "lodash", "axios"],
       input: Object.fromEntries(
         // https://rollupjs.org/configuration-options/#input
         glob.sync('lib/**/*.{ts,tsx}', {
-          ignore: ["lib/**/*.d.ts"],
+          ignore: ["lib/**/*.d.ts", "lib/**/*.types.ts"],
         }).map(file => [
           // 1. The name of the entry point
           // lib/nested/foo.js becomes nested/foo


### PR DESCRIPTION
New Updates and bugfixes:
- LiveView initialises image at a scale that correctly fills the bounding area (either scaled down or up to fit).
    - LiveView zoom controls changed so there's a button to return to this original zoom level, as well as zooming to 100% scale
- AdapterEndpoint now repeatedly attempts to reconnect to an Adapter if the connection fails for whatever reason.
    - On reconnection, WithEndpoint components using that AdapterEndpoint object will reset their values and type declarations to whatever is received from the new connection to the Adapter. This is because it's assumed the connection loss may well have been due to the Adapter stopping and starting, so the old displayed values may no longer be accurate.