### PR TITLE
Feature/pin error message

### DIFF
--- a/lib/components/OdinApp/index.tsx
+++ b/lib/components/OdinApp/index.tsx
@@ -59,6 +59,7 @@ interface routeAppProps extends PropsWithChildren{
 }
 
 const darkModeAttr = "data-bs-theme";
+const buttonSvgSize = "2em";
 
 const RouteApp: React.FC<routeAppProps> = (props) => {
     
@@ -254,6 +255,20 @@ const OdinApp: React.FC<OdinAppProps> = (props: OdinAppProps) =>
             curDarkMode == "dark" ? "light" : "dark");
     }
 
+    const [scrollPosition, setScrollPosition] = useState(0);
+    const handleScroll = () => {
+        const position = window.pageYOffset;
+        setScrollPosition(position);
+    }
+
+    useEffect(() => {
+        window.addEventListener("scroll", handleScroll, {passive: true});
+
+        return () => {
+            window.removeEventListener("scroll", handleScroll);
+        }
+    }, []);
+
     const ErrorPopover = (
         <Popover className={styles.errorPopover}>
             <Popover.Header>
@@ -274,11 +289,11 @@ const OdinApp: React.FC<OdinAppProps> = (props: OdinAppProps) =>
     <ErrorBoundary FallbackComponent={Fallback}>
         {/* <OdinErrorContext> */}
         <HashRouter>
-            <Navbar className='bg-body-secondary'>
-                <Navbar.Brand href='/'>
+            <Navbar className='bg-body-secondary' sticky='top'
+                style={{boxShadow: `0px 0px ${Math.min(scrollPosition, 30)}px`}}>
+                <Navbar.Brand href='/' className={styles.navBrand}>
                     <img
                     src={icon_addr}
-                    height="30"
                     style={{marginLeft: icon_marginLeft, marginRight: icon_marginRight}}
                     className="d-inline-block align-top"
                     alt="Odin Control Logo"
@@ -293,7 +308,7 @@ const OdinApp: React.FC<OdinAppProps> = (props: OdinAppProps) =>
                     <OverlayTrigger overlay={ErrorPopover} trigger="click" placement='bottom-end'>
                         <Nav className={styles.navbarBtn}>
                             <Button className={`${styles.btn} ${styles.errorBtn}`} variant='outline-danger'>
-                                <ExclamationCircleFill className={styles.svg} title="See Errors" size={32}/>
+                                <ExclamationCircleFill className={styles.svg} title="See Errors" size={buttonSvgSize}/>
                                 <Badge bg="none" className={styles.errorCountBadge} pill>
                                     {errors.reduce((a, b) => (a + b.count), 0)}
                                 </Badge>
@@ -304,8 +319,8 @@ const OdinApp: React.FC<OdinAppProps> = (props: OdinAppProps) =>
                 }
                 <Nav className={`${styles.navbarBtn} d-none d-md-block`}>
                     <Button className={`${styles.btn} ${styles.darkmode}`} onClick={toggleTheme} variant='none'>
-                        <LightbulbFill className={`${styles.svg} ${styles.dark}`} title='Set Light Mode' size={32}/>
-                        <MoonFill className={`${styles.svg} ${styles.light}`} title='Set Dark Mode' size={32}/>
+                        <LightbulbFill className={`${styles.svg} ${styles.dark}`} title='Set Light Mode' size={buttonSvgSize}/>
+                        <MoonFill className={`${styles.svg} ${styles.light}`} title='Set Dark Mode' size={buttonSvgSize}/>
                     </Button>
                 </Nav>
             </Navbar>

--- a/lib/components/OdinApp/styles.module.css
+++ b/lib/components/OdinApp/styles.module.css
@@ -1,17 +1,23 @@
 .navbarBtn {
-    padding: 0 .5rem;
+    padding: 0 .5em;
     background-color: var(--bs-secondary-bg);
 }
 
 .navContainer {
     overflow-x: clip;
     min-width: 50px;
-    margin-right: 0.5rem;
+    margin-right: 0.5em;
     :global(.btn) {
         z-index: 2;
     }
 }
+.navBrand {
+    font-size: 1.25em;
 
+    :global(img) {
+        height: 1.25em;
+    }
+}
 .navLink {
     position: relative;
     transition: right .15s;
@@ -23,12 +29,13 @@
 
 .notFound {
     text-align: center;
-    margin-top: 3rem;
+    margin-top: 3em;
 }
 
 .btn {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 2.5em;
+    height: 2.5em;
+    font-size: 1em;
     align-items: center;
     justify-content: center;
     border-radius: 50%;

--- a/lib/components/OdinErrorContext/index.tsx
+++ b/lib/components/OdinErrorContext/index.tsx
@@ -146,20 +146,28 @@ const ErrorAlert: React.FC<ErrorAlertProps> = ({error, className, ...props}) => 
 }
 
 
-const OdinErrorOutlet: React.FC<{height?: CSSProperties["height"]}> = ({height = "calc(100vh - 10rem)"}) => {
+const OdinErrorOutlet: React.FC<{height?: CSSProperties["height"]}> = ({height = "calc(100vh - 15rem)"}) => {
 
     const {errors} = useError();
 
+    const secondsSinceError = errors.length > 0 ? (new Date().getTime() - errors[0].timestamp.getTime())/1000 : -1;
+    const lastErrorMessage = (secondsSinceError > 3600) ? "over an Hour ago" :
+                             (secondsSinceError > 60) ? `${Math.floor(secondsSinceError/60)} minutes, ${Math.floor(secondsSinceError % 60)} seconds ago` :
+                             "just now";
 
     return (
         errors.length > 0 && (
-            <div className={Style.scrollable} style={{maxHeight: height}}>
-            {errors.slice(0, 100).map((err, index) => (
-                <ErrorAlert error={err} key={index}/>
-            ))}
-            {errors.length >=100 &&
-            <Alert key="culled_err_warn" variant="warning" transition={false}>Additional Errors not shown</Alert>}
-            </div>
+            <>
+                <div>{`Last Error occured ${lastErrorMessage}`}</div>
+                <hr/>
+                <div className={Style.scrollable} style={{maxHeight: height}}>
+                    {errors.slice(0, 100).map((err, index) => (
+                        <ErrorAlert error={err} key={index}/>
+                    ))}
+                    {errors.length >=100 &&
+                    <Alert key="culled_err_warn" variant="warning" transition={false}>Additional Errors not shown</Alert>}
+                </div>
+            </>
         )
     )
 }

--- a/lib/components/OdinErrorContext/styles.module.css
+++ b/lib/components/OdinErrorContext/styles.module.css
@@ -3,12 +3,12 @@
 }
 
 .errorAlert.latest {
-  position: absolute;
+  position: fixed;
   right: .5rem;
   margin-top: .5rem;
   max-width: 50vw;
   z-index: 5;
-  opacity: 50%;
+  opacity: 90%;
   transition: opacity .15s linear;
 }
 


### PR DESCRIPTION
Navbar/Error messages are pinned to the top of the screen, even when the user scrolls
Also added a description in the Error Outlet that says how long ago the last error occurred

Also changed the opacity of the single Error Message that appears, as some users thought the low opacity was a rendering bug, rather than intentional. It's now at 90% opacity when un-hovered, so still has a very minor transparency until the mouse hovers over, but this should not cause the same confusion.

fixes #92
fixes #100 
 