### PR TITLE
Modified WithEndpoint to remove Uncontrolled to Controlled console error

### DIFF
--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -115,6 +115,7 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
 
         const componentPassedValue = useMemo(() => {
             const curComponent = component.current;
+            const val = componentValue ?? "";
             if(curComponent){
                 // coded using switch case to future proof if there's other special case component types
                 switch(curComponent.nodeName){
@@ -124,16 +125,16 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                             switch(input_type){
                                 case "checkbox":
                                 case "radio":
-                                    return {checked: componentValue};
+                                    return {checked: Boolean(val)};
                                 default:
-                                    return {value: componentValue};
+                                    return {value: val};
                             }
                         }
                     default:
-                        return {value: componentValue};
+                        return {value: val};
                 }
             }
-            return {value: componentValue};
+            return {value: "", checked: false};
         }, [component.current, componentValue]);
 
         const validate = (value: ComponentProps['value']) => {


### PR DESCRIPTION
WithEndpoint components no longer default the value as Undefined when the underlying component/param from the Adapter has not yet been loaded. This should avoid the "uncontrolled to controlled" error without affecting actual performance, since this default will only be used until either the user changes the component's value, or the adapter endpoint does.

fixes #91 