### PR TITLE
Added typing for the Endpoint Metadata tree

### DIFF
--- a/control/src/react/controller.py
+++ b/control/src/react/controller.py
@@ -35,6 +35,8 @@ class ReactController():
         self.last_name = ""
         self.age = 0
 
+        self.float_val = 1.5
+
         self.slow_put = 5
 
         self.param_tree = ParameterTree({
@@ -44,8 +46,8 @@ class ReactController():
                             "min": 15,
                             "max": 76
                         }),
+            "float_val": (lambda: self.float_val, lambda val: setattr(self, "float_val", val)),
             "rand_num": (lambda: self.random_num, None),
-            "select_list": (lambda: self.selection_list, None),
             "selected": (lambda: self.selected, self.set_selection,
                         {  # metadata
                             "allowed_values": self.selection_list

--- a/lib/components/AdapterEndpoint/AdapterEndpoint.types.ts
+++ b/lib/components/AdapterEndpoint/AdapterEndpoint.types.ts
@@ -2,7 +2,7 @@ import type { AxiosRequestConfig } from "axios";
 
 type status = "init" | "connected" | "error";
 
-interface AdapterEndpoint<T = NodeJSON> {
+interface AdapterEndpoint<T extends ParamNode = ParamNode> {
     /**
      *  Recursive Nested dictionary structure representing the adapter Param Tree. Should be read only
      * from this interface
@@ -12,7 +12,7 @@ interface AdapterEndpoint<T = NodeJSON> {
     /**
      * Dictionary structure containing the adapter Metadata, if its implimented by the adapter
      */
-    metadata: Readonly<NodeJSON>;
+    metadata: Readonly<Metadata<T>>;
     /**
      *  Any Errors that occur during http methods or otherwise will be accessible here
      */
@@ -39,24 +39,24 @@ interface AdapterEndpoint<T = NodeJSON> {
      * @param {boolean} [get_metadata] - set to true to request Metadata. Defaults to false
      * @returns An Async promise, that when resolved will return the data within the HTTP response
      */
-    get: <T = NodeJSON>(param_path?: string, config?: getConfig) => Promise<T>;
+    get: <T = ParamNode>(param_path?: string, config?: getConfig) => Promise<T>;
     /**
      * Async http PUT method. Modify the data in the param tree at the provided path
      * It is worth noting that this method does NOT automatically merge the response into the Endpoint.Data object.
-     * @param {NodeJSON} data - The data, with a key, that you wish to PUT to the Param Tree
+     * @param {ParamNode} data - The data, with a key, that you wish to PUT to the Param Tree
      * @param {string} param_path - the path you want to PUT to. Defaults to an empty string for a top level PUT
      * @returns An Async promise, that when resolved will return the data within the HTTP response
      */
-    put: (data: NodeJSON, param_path?: string) => Promise<NodeJSON>;
+    put: (data: ParamNode, param_path?: string) => Promise<ParamNode>;
 
     /**
      * Async http POST method. Not often implemented by Adapters, but potentially used to post data
      * files or some other new data to the adapter
-     * @param {NodeJSON} data - The data, with a key, that you wish to POST to the adapter
+     * @param {ParamNode} data - The data, with a key, that you wish to POST to the adapter
      * @param param_path  - the path you want to POST to. defaults to an empty string, for a top level POST
      * @returns An Async promise, that when resolved will return the data within the HTTP response
      */
-    post: (data: NodeJSON, param_path?: string) => Promise<NodeJSON>;
+    post: (data: ParamNode, param_path?: string) => Promise<ParamNode>;
 
     /**
      * Async http DELETE method. Renamed because 'delete' is a reserved word in javascript. Not often
@@ -64,7 +64,7 @@ interface AdapterEndpoint<T = NodeJSON> {
      * @param param_path the path to the data you want to DELETE. Defaults to an empty string
      * @returns An Async promise, that when resolved will return the data within the HTTP response
      */
-    remove: (param_path?: string) => Promise<NodeJSON>;
+    remove: (param_path?: string) => Promise<ParamNode>;
     /**
      * A method to automatically perform a top level GET request and refresh the AdapterEndpoint's current view of the data
      * @returns 
@@ -73,32 +73,65 @@ interface AdapterEndpoint<T = NodeJSON> {
     /**
      * A method to merge one chunk of (potentially nested) data into the AdapterEndpoint's current view of the data,
      * to update the data without having to GET from the entire adapter
-     * @param {NodeJSON} newData - The new data to be merged in
+     * @param {ParamNode} newData - The new data to be merged in
      * @param {string} param_path - the location that data within the ParamTree to merge it
      * @returns 
      */
-    mergeData: (newData: NodeJSON, param_path: string) => void;
+    mergeData: (newData: ParamNode, param_path: string) => void;
 
 }
 
-/**
- * Defines allowed values for JSON dict.
- */
-type JSON = string | number | boolean | null | undefined | JSON[] | NodeJSON;
+/** Defines allowed values for paramater primatives. */
+type Parameter = string | number | boolean | null | undefined;
 
-/**
- * JSON Dict, defines key/value pairing.
- */
-type NodeJSON = {[key:string]: JSON};
+/** Dict structure for the Parameters. */
+type ParamNode = {[key:string]: ParamTree};
+
+/** Any possible value from the Param Tree (Basically any possible JSON value)
+ * This could be a primative value, a dict structure, or an array of any of these values.
+ * This flexibility allows for the recursive nested structure of the Parameter Tree
+*/
+type ParamTree = Parameter | ParamTree[] | ParamNode;
+
+
+type ParamNum = "int" | "float" | "complex" | "bool"
+type ParamList = "list" | "tuple" | "range"
+/**Possible Type values from Python */
+type ParamType = ParamNum | ParamList | "str" | "NoneType"
+
+/** Structure of the Metadata for a single Parameter */
+interface MetadataValue<T extends ParamTree = ParamTree> extends ParamNode {
+    value: T;
+    type: ParamType;
+    writeable: boolean;
+    min?: number;
+    max?: number;
+    allowed_values?: T[];
+    name?: string;
+    description?: string;
+    units?: string;
+    display_precision?: string;
+
+}
+
+/** Structure for the full Metadata Tree of an Adapter */
+type Metadata<T extends ParamNode = ParamNode> = {
+    [Property in keyof T]: 
+        T[Property] extends ParamNode ? 
+            Metadata<T[Property]> :
+            T[Property] extends Parameter ?
+                MetadataValue<T[Property]> :
+                T[Property] // ????
+}
 
 interface getConfig {
     wants_metadata?: boolean;
     responseType?: AxiosRequestConfig['responseType'];
 }
 
-export type { AdapterEndpoint, JSON, NodeJSON, getConfig, status};
+export type { AdapterEndpoint, Metadata, MetadataValue, Parameter, ParamNode, ParamTree, getConfig, status};
 
 /**
  * @deprecated This is the old name for this type and should be replaced with "AdapterEndpoint"
  */
-export type AdapterEndpoint_t<T> = AdapterEndpoint<T>;
+export type AdapterEndpoint_t<T extends ParamNode> = AdapterEndpoint<T>;

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
-import type { AdapterEndpoint, JSON, NodeJSON, getConfig, status } from "./AdapterEndpoint.types";
+import type { AdapterEndpoint, Metadata, Parameter, ParamNode, ParamTree, getConfig, status } from "./AdapterEndpoint.types";
 import { useError } from "../OdinErrorContext";
 
 const DEF_API_VERSION = '0.1';
@@ -13,7 +13,7 @@ enum updateFlag_enum {
     ERROR = "error"
 }
 
-const isParamNode = (x: JSON): x is NodeJSON => {
+const isParamNode = (x: ParamTree): x is ParamNode => {
     return x !== null && typeof x === "object" && !Array.isArray(x);
 }
 
@@ -24,7 +24,7 @@ const isParamNode = (x: JSON): x is NodeJSON => {
  * @returns the value at the specified path (which is either a single value, or a JSON Node with Key/Val pair(s))
  * or Undefined if the value was not found at that path
  */
-function getValueFromPath<T>(data: JSON, path: string): T | undefined {
+function getValueFromPath<T = Parameter>(data: ParamTree, path: string): T | undefined {
     const splitPath = path.split("/");
     if(splitPath[0]){
         splitPath.forEach((pathPart) => {
@@ -41,12 +41,12 @@ function getValueFromPath<T>(data: JSON, path: string): T | undefined {
 }
 
 
-function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
+function useAdapterEndpoint<T extends ParamNode = ParamNode>(
     adapter: string, endpoint_url: string, interval?: number, timeout?: number, api_version=DEF_API_VERSION
 ): AdapterEndpoint<T> {
 
     const data = useRef<T>({} as T);
-    const [metadata, setMetadata] = useState<NodeJSON>({});
+    const [metadata, setMetadata] = useState<Metadata<T>>({} as Metadata<T>);
     const [error, setError] = useState<Error | null>(null);
     const [updateFlag, setUpdateFlag] = useState(Symbol(updateFlag_enum.INIT));
     const [statusFlag, setStatusFlag] = useState<status>("init");
@@ -89,7 +89,7 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
         return error;  // rethrow error so it doesn't dissapear
     };
 
-    const get = async <T = NodeJSON>(param_path='', config?: getConfig) => {
+    const get = async <T = ParamNode>(param_path='', config?: getConfig) => {
         console.debug(`GET: ${base_url}/${param_path}`);
 
         const {wants_metadata=false, responseType='json'} = config ?? {};
@@ -116,11 +116,11 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
         }
     };
 
-    const put = async (data: NodeJSON, param_path='') => {
+    const put = async (data: ParamNode, param_path='') => {
         // const url = [base_url, param_path].join("/"); // assumes param_path does not start with a slash
         console.debug(`PUT: ${base_url}/${param_path}, data: `, data);
         
-        let result: NodeJSON = {};
+        let result: ParamNode = {};
         let response: AxiosResponse<typeof result>;
 
         try {
@@ -140,10 +140,10 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
         }
     };
 
-    const post = async (data: NodeJSON, param_path="") => {
+    const post = async (data: ParamNode, param_path="") => {
         console.debug(`POST: ${base_url}/${param_path}, data: `, data);
 
-        let result: NodeJSON = {};
+        let result: ParamNode = {};
         let response: AxiosResponse<typeof result>;
 
         try {
@@ -166,7 +166,7 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
     const remove = async (param_path="") => {
         console.debug(`DELETE: ${base_url}/${param_path}`);
 
-        let result: NodeJSON = {};
+        let result: ParamNode = {};
         let response: AxiosResponse<typeof result>;
 
         try {
@@ -198,7 +198,7 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
         });
         get("", {wants_metadata: true})
         .then(result => {
-            setMetadata(result);
+            setMetadata(result as Metadata<T>);
             setStatusFlag("connected");
             setUpdateFlag(Symbol(updateFlag_enum.FIRST))
         })
@@ -239,10 +239,10 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
         });
     }
     
-    const mergeData = (newData: NodeJSON, param_path: string) => {
+    const mergeData = (newData: ParamNode, param_path: string) => {
         const splitPath = param_path.split("/").slice(0, -1);
         const tmpData = data.current;  // use tmpData as a copy of the Data that we can modify
-        let pointer: JSON = tmpData;  // pointer that can traverse down the nested data
+        let pointer: ParamNode[keyof ParamNode] = tmpData;  // pointer that can traverse down the nested data
 
         if(splitPath[0]) {
             splitPath.forEach((part_path) => {
@@ -261,4 +261,14 @@ function useAdapterEndpoint<T extends NodeJSON = NodeJSON>(
 }
 
 export { useAdapterEndpoint, isParamNode, getValueFromPath };
-export type { AdapterEndpoint, JSON, NodeJSON };
+export type { AdapterEndpoint, Parameter, ParamNode, Metadata, ParamTree };
+
+/**
+ * @deprecated This is the old name for this type and should be replaced with "Parameter"
+ */
+export type JSON = ParamTree
+
+/**
+ * @deprecated This is the old name for this type, and should be replaced with "ParamNode"
+ */
+export type NodeJSON = ParamNode

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
-import type { AdapterEndpoint, JSON } from "../AdapterEndpoint";
+import type { AdapterEndpoint, ParamNode, ParamTree } from "../AdapterEndpoint";
+import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { isParamNode, getValueFromPath } from "../AdapterEndpoint";
 import { useError } from "../OdinErrorContext";
 import { isEqual } from 'lodash';
@@ -14,7 +15,7 @@ type value_t = "string" | "number" | "boolean" | "null" | "list" | "dict"
 interface ComponentProps {
     endpoint: AdapterEndpoint;
     fullpath: string;
-    value?: JSON;
+    value?: ParamNode[keyof ParamNode];
     // value_type?: value_t;
     min?: number;
     max?: number;
@@ -29,10 +30,10 @@ interface ComponentProps {
 }
 
 interface metadata_t {
-    readOnly: boolean;
+    readOnly: MetadataValue["writeable"];
     min?: number;
     max?: number;
-    allowed_values?: JSON[];
+    allowed_values?: MetadataValue["allowed_values"];
     type?: string;
 }
 
@@ -194,19 +195,19 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                 return false;
             }
             if(endpointLoaded() && endpoint.status != "error"){
-                let data = getValueFromPath<ComponentProps['value']>(endpoint.metadata, fullpath);
-                let val: JSON;
+                const metadata = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath);
+                let val: ParamTree;
                 const tmp_metadata: metadata_t = {readOnly: false, min: min, max: max};
-                if(isParamNode(data) && "writeable" in data){ //metadata found
-                    tmp_metadata.readOnly = !(data['writeable'] as boolean);
-                    tmp_metadata.min = min ?? (data.min ? data.min as number : undefined);
-                    tmp_metadata.max = max ?? (data.max ? data.max as number : undefined);
-                    tmp_metadata.allowed_values = data?.allowed_values as JSON[];
+                if(isParamNode(metadata) && "writeable" in metadata){ //metadata found
+                    tmp_metadata.readOnly = !(metadata.writeable);
+                    tmp_metadata.min = min ?? (metadata.min ? metadata.min : undefined);
+                    tmp_metadata.max = max ?? (metadata.max ? metadata.max : undefined);
+                    tmp_metadata.allowed_values = metadata?.allowed_values;
 
                     // setMetadata(tmp_metadata);
-                    val = value ?? data.value as ComponentProps["value"];
+                    val = value ?? metadata.value;
 
-                    switch(data.type as string){
+                    switch(metadata.type as string){
                         case "int":
                         case "float":
                         case "complex":
@@ -227,11 +228,11 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                             setType("null");
                             break;
                         default:
-                            setType(data.type as value_t);
+                            setType(metadata.type as value_t);
                     }
 
                 }else{
-                    data = getValueFromPath<ComponentProps['value']>(endpoint.data, fullpath);
+                    const data = getValueFromPath<ComponentProps['value']>(endpoint.data, fullpath);
                     console.debug("Adapter has not implemented Metadata for", fullpath);
                     val = value ?? data as ComponentProps["value"];
                     const data_type = (value == null ? typeof data : typeof value);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -11,7 +11,7 @@ export { OdinLiveView, ZoomableImage } from './components/OdinLiveView';
 export { ParamController } from './components/ParamController';
 
 export type { GraphData, Axis } from './components/OdinGraph';
-export type { AdapterEndpoint, NodeJSON as ParamTree } from "./components/AdapterEndpoint";
+export type { AdapterEndpoint, ParamNode, ParamTree } from "./components/AdapterEndpoint";
 export type { AdapterEndpoint_t } from "./components/AdapterEndpoint/AdapterEndpoint.types";
 export type { Log } from './components/OdinEventLog';
 

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -1,7 +1,7 @@
 import { Container, Row, Col, Stack, Form, InputGroup, Alert, Dropdown, FloatingLabel } from "react-bootstrap"
 import { TitleCard, WithEndpoint, OdinDoubleSlider } from "../"
 import { EndpointInput, EndpointButton, EndpointDropdown, EndpointCheckbox } from "../";
-import type { ParamTree, Log} from "../";
+import type { ParamNode, Log} from "../";
 import { useState } from "react";
 import { AdapterEndpoint } from "../";
 
@@ -14,17 +14,17 @@ const EndpointSlider = WithEndpoint(OdinDoubleSlider);
 // const EndpointCheckbox = WithEndpoint(Form.Check);
 const EndpointSelect = WithEndpoint((props: React.HTMLAttributes<HTMLSelectElement>) => (<select {...props}>{props.children as ReactNode}</select>))
 
-interface FormData_T extends ParamTree{
+interface FormData_T extends ParamNode{
     first_name: string;
     last_name: string;
     age: number;
 }
 
-export interface EndpointData extends ParamTree{
+export interface EndpointData extends ParamNode{
     string_val: string;
     num_val: number;
+    float_val: number;
     rand_num: number;
-    select_list: string[];
     selected: string;
     toggle: boolean;
     trigger: null;
@@ -60,7 +60,6 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
     const [input, changeInput] = useState(0);
     const [formData, changeFormData] = useState<FormData_T>({first_name: "", last_name: "", age: 0});
 
-
     return (
         <Container>
             <Row>
@@ -93,7 +92,7 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                         <Stack>
                         <EndpointDropdown endpoint={endpoint} fullpath="selected"
                             title={endpoint.data.selected || "Unknown"}>
-                                {endpoint.data.select_list ? endpoint.data.select_list.map(
+                                {endpoint.metadata?.selected?.allowed_values ? endpoint.metadata.selected.allowed_values.map(
                                     (selection, index) => (
                                         <Dropdown.Item eventKey={selection} key={index}>{selection}</Dropdown.Item>
                                     )): <></>
@@ -101,7 +100,7 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                         </EndpointDropdown>
                         <label>Choose Option:
                             <EndpointSelect endpoint={endpoint} fullpath="selected">
-                                {endpoint.data.select_list ? endpoint.data.select_list.map(
+                                {endpoint.metadata?.selected?.allowed_values ? endpoint.metadata.selected.allowed_values.map(
                                     (selection, index) => {
                                         return <option key={index} value={selection}>{selection}</option>;
                                 }) : <option value="">Unknown</option>


### PR DESCRIPTION
Metadata tree type automatically created from the Param Tree interface provided to an Adapter Endpoint.
Modified the naming convention of the Parameter Tree types to avoid collision with standard JSON type