### PR TITLE
Odin Control 2.0 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ package-lock.json
 *.egg-info
 __pycache__
 */build
+*_version.py

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "odin-control @ git+https://github.com/odin-detector/odin-control.git@dev_2.0",
-    "odin-data @ git+https://git@github.com/odin-detector/odin-data.git#subdirectory=python",
+    # "odin-data @ git+https://git@github.com/odin-detector/odin-data.git#subdirectory=python",
     "python-dateutil",
     "opencv-python"
 ]
@@ -20,3 +20,7 @@ name = "Ashley Neaves"
 
 [project.urls]
 github = "https://github.com/stfc-aeg/odin-react"
+
+[tool.setuptools_scm]
+root = ".."
+write_to = "control/src/react/_version.py"

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -8,7 +8,7 @@ description = "Demo Odin Control adapter for React Testing and Demonstration"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "odin-control @ git+https://github.com/odin-detector/odin-control",
+    "odin-control @ git+https://github.com/odin-detector/odin-control.git@dev_2.0",
     "odin-data @ git+https://git@github.com/odin-detector/odin-data.git#subdirectory=python",
     "python-dateutil",
     "opencv-python"

--- a/control/src/react/__init__.py
+++ b/control/src/react/__init__.py
@@ -1,0 +1,3 @@
+"""React demo Adapter __init__.py"""
+
+from ._version import __version__

--- a/control/src/react/adapter.py
+++ b/control/src/react/adapter.py
@@ -1,7 +1,7 @@
-from odin_control._version import __version__
 from odin_control.adapters.adapter import ApiAdapter
 from odin_control.adapters.parameter_tree import ParameterTreeError
 from react.controller import ReactController
+from react import __version__
 
 
 class ReactAdapter(ApiAdapter):

--- a/control/src/react/adapter.py
+++ b/control/src/react/adapter.py
@@ -1,78 +1,11 @@
-import logging
-
-from odin.adapters.adapter import (ApiAdapter, ApiAdapterResponse,
-                                   request_types, response_types, wants_metadata)
-from odin.adapters.parameter_tree import ParameterTreeError
-from odin.util import decode_request_body
-
+from odin_control._version import __version__
+from odin_control.adapters.adapter import ApiAdapter
+from odin_control.adapters.parameter_tree import ParameterTreeError
 from react.controller import ReactController
 
 
 class ReactAdapter(ApiAdapter):
 
-    def __init__(self, **kwargs):
-
-        super().__init__(**kwargs)
-
-        self.controller = ReactController()
-
-        logging.debug("React Adapter Loaded")
-
-    @response_types('application/json', default='application/json')
-    def get(self, path, request):
-        """Handle an HTTP GET request.
-
-        This method handles an HTTP GET request, returning a JSON response.
-
-        :param path: URI path of request
-        :param request: HTTP request object
-        :return: an ApiAdapterResponse object containing the appropriate response
-        """
-        logging.debug(request.query_arguments)
-        metadata = wants_metadata(request)
-        try:
-            query = {k: [val.decode("utf-8") for val in v] for (k, v) in request.query_arguments.items()}
-            response = self.controller.get(path, metadata, query)
-            status_code = 200
-        except (ParameterTreeError) as e:
-            response = {'error': str(e)}
-            status_code = 400
-
-        content_type = 'application/json'
-
-        return ApiAdapterResponse(response, content_type=content_type,
-                                  status_code=status_code)
-
-    @request_types('application/json', 'application/vnd.odin-native')
-    @response_types('application/json', default='application/json')
-    def put(self, path, request):
-        """Handle an HTTP PUT request.
-
-        This method handles an HTTP PUT request, decoding the request and attempting to set values
-        in the asynchronous parameter tree as appropriate.
-        :param path: URI path of request
-        :param request: HTTP request object
-        :return: an ApiAdapterResponse object containing the appropriate response
-        """
-        content_type = 'application/json'
-
-        try:
-            data = decode_request_body(request)
-            response = self.controller.set(path, data)
-            status_code = 200
-        except (ParameterTreeError) as e:
-            response = {'error': str(e)}
-            status_code = 400
-
-        return ApiAdapterResponse(
-            response, content_type=content_type, status_code=status_code
-        )
-
-    def cleanup(self):
-        """Clean up the adapter.
-
-        This method stops the background tasks, allowing the adapter state to be cleaned up
-        correctly.
-        """
-        logging.debug("Cleanup called")
-        self.controller.cleanup()
+    version = __version__
+    controller_cls = ReactController
+    error_cls = ParameterTreeError

--- a/control/src/react/controller.py
+++ b/control/src/react/controller.py
@@ -113,7 +113,7 @@ class ReactController(BaseController):
         self.toggle = val
 
     def trigger_event(self, val):
-        self.logger.info("Event Triggered by API with value: %s", val)
+        logging.info("Event Triggered by API with value: %s", val)
 
     def set_slow_response_val(self, val):
         time.sleep(2.5)  # simulating complex get request or slow network
@@ -135,6 +135,7 @@ class ReactController(BaseController):
         return val
 
     def set(self, path, data):
+        logging.info("PUT: %s to path %s", data, path)
         self.param_tree.set(path, data)
         return self.param_tree.get(path)
     

--- a/control/src/react/controller.py
+++ b/control/src/react/controller.py
@@ -19,7 +19,7 @@ class ReactController(BaseController):
         self.clip_data = [-10, 5]
 
         self.string_val = "String Value Test"
-        self.num_val = 10
+        self.num_val = 15
         self.random_num = random.randint(0, 100)
 
         self.selection_list = ["item 1", "item 2", "item 3"]
@@ -120,7 +120,7 @@ class ReactController(BaseController):
         self.slow_put = val
 
     def get(self, path, metadata=False, kwargs=None):
-        # self.logger.debug("GETTING PATH: %s", path)
+        logging.info("GETTING PATH: %s%s", path, " with METADATA" if metadata else "")
 
         # special Log Filtering with the query Args!
         if path == "logging" and kwargs:

--- a/control/src/react/controller.py
+++ b/control/src/react/controller.py
@@ -1,15 +1,16 @@
 import logging
 import random
-from odin.adapters.parameter_tree import ParameterTree
+from odin_control.adapters.parameter_tree import ParameterTree
+from odin_control.adapters.base_controller import BaseController
 from tornado.ioloop import PeriodicCallback
 from react.event_logger import EventLogger
 
 import time
 
 
-class ReactController():
+class ReactController(BaseController):
 
-    def __init__(self) -> None:
+    def __init__(self, options=None) -> None:
 
         self.deep_dict_val = "secret deep value"
         self.deep_dict_num = 42

--- a/control/test/config/react_example.cfg
+++ b/control/test/config/react_example.cfg
@@ -3,16 +3,13 @@ debug_mode = 1
 http_port = 8889
 http_addr = 127.0.0.1
 enable_cors = true
-adapters = system_info, react, live_view
+adapters = system_info, react
 
 [tornado]
 logging = debug
 
 [adapter.system_info]
-module = odin.adapters.system_info.SystemInfoAdapter
+module = odin_control.adapters.system_info.SystemInfoAdapter
 
 [adapter.react]
 module = react.adapter.ReactAdapter
-
-[adapter.live_view]
-module = odin_data.control.live_view_adapter.LiveViewAdapter

--- a/lib/components/AdapterEndpoint/AdapterEndpoint.types.ts
+++ b/lib/components/AdapterEndpoint/AdapterEndpoint.types.ts
@@ -32,6 +32,12 @@ interface AdapterEndpoint<T extends ParamNode = ParamNode> {
      * Connection status for the AdapterEndpoint.
      */
     status: status;
+
+    /**
+     * Api String. Used to differentiate between Odin Control versions.
+     * If blank, Odin Control is v2.*
+     */
+    apiVersion: string;
     /**
      * Async http GET method. Request the provided value(s) from the parameter tree.
      * It is worth noting that this method does NOT automatically merge the response into the Endpoint.Data object.
@@ -47,7 +53,7 @@ interface AdapterEndpoint<T extends ParamNode = ParamNode> {
      * @param {string} param_path - the path you want to PUT to. Defaults to an empty string for a top level PUT
      * @returns An Async promise, that when resolved will return the data within the HTTP response
      */
-    put: (data: ParamNode, param_path?: string) => Promise<ParamNode>;
+    put: <T = Parameter>(data: {[key: string]: T}, param_path?: string) => Promise<{[Property in keyof typeof data]: T}>;
 
     /**
      * Async http POST method. Not often implemented by Adapters, but potentially used to post data
@@ -102,14 +108,23 @@ type ParamType = ParamNum | ParamList | "str" | "NoneType"
 /** Structure of the Metadata for a single Parameter */
 interface MetadataValue<T extends ParamTree = ParamTree> extends ParamNode {
     value: T;
+    /**Python Type of the Parameter */
     type: ParamType;
+    /**Is the Parameter editable */
     writeable: boolean;
+    /**Minimum value for the Parameter (if a number type) */
     min?: number;
+    /**Maximum value for the Parameter (if a number type) */
     max?: number;
+    /**Array of permitted values for the Parameter*/
     allowed_values?: T[];
+    /**Human readable name of the Parameter*/
     name?: string;
+    /**Description of what the Parameter represents*/
     description?: string;
+    /**What units the Parameter is in (such as cm, degrees C, etc)*/
     units?: string;
+    /**Display precision for float/integer Parameters*/
     display_precision?: string;
 
 }

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -3,7 +3,9 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import type { AdapterEndpoint, Metadata, Parameter, ParamNode, ParamTree, getConfig, status } from "./AdapterEndpoint.types";
 import { useError } from "../OdinErrorContext";
 
-const DEF_API_VERSION = '0.1';
+// odin control 2.0 no longer uses an API Version.
+// TODO: How to auto detect if we're using odin control 2.0 or not?
+// const DEF_API_VERSION = '';
 
 enum updateFlag_enum {
     INIT = "init",
@@ -42,7 +44,7 @@ function getValueFromPath<T = Parameter>(data: ParamTree, path: string): T | und
 
 
 function useAdapterEndpoint<T extends ParamNode = ParamNode>(
-    adapter: string, endpoint_url: string, interval?: number, timeout?: number, api_version=DEF_API_VERSION
+    adapter: string, endpoint_url: string, interval?: number, timeout?: number
 ): AdapterEndpoint<T> {
 
     const data = useRef<T>({} as T);
@@ -51,11 +53,16 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
     const [updateFlag, setUpdateFlag] = useState(Symbol(updateFlag_enum.INIT));
     const [statusFlag, setStatusFlag] = useState<status>("init");
 
+    const [apiVersion, setApiVersion] = useState<string>("");
+    const [base_url, setBaseUrl] = useState<string>([endpoint_url,
+                                                    "api",
+                                                    apiVersion,
+                                                    adapter
+                                                    ].filter(Boolean).join("/"));
+    
     const [awaiting, changeAwaiting] = useState(false);
 
     const ctx = useError();
-
-    const base_url = `${endpoint_url ? endpoint_url : ""}/api/${api_version}/${adapter}`;
     const axiosInstance: AxiosInstance = axios.create({
         baseURL: base_url,
         timeout: timeout,
@@ -72,6 +79,7 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
             if(err.response) {
                 const method = err.response.config.method ? err.response.config.method.toUpperCase() : "UNDEFINED";
                 const reason = err.response.data?.error || "";
+                // const address = err.response
                 errorMsg = `${method} request failed with status ${err.response.status} : ${reason}`;
             }
             else if (err.request) {
@@ -189,21 +197,41 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
     // some sort of looping attempt at first connection until we get a response? so if the adapter
     // isn't running at first for whatever reason, we keep trying until it is?
     const getInitialData = () => {
-        get("")
+        // discover Odin Control version (1.* or 2.*, changes what the full URL needs to be)
+        let url = [endpoint_url, "api"].filter(Boolean).join("/");
+        console.debug("Checking Odin Control Version");
+
+        //can't use the get function of the endpoint yet, because we don't know if the base_url is correct
+        // until we've worked out if we need the api "0.1" yet.
+        axios.get<{api?: number}>(url)
         .then(result => {
-            data.current = result as T;
+            const api_version = result.data?.api ? result.data.api.toString() : "";
+            
+            setApiVersion(api_version);
+            url = [url, api_version, adapter].filter(Boolean).join("/");
+            setBaseUrl(url);
+
+            axios.get(url)
+            .then(result => {
+                data.current = result.data as T;
+            })
+            .catch(err => {
+                throw handleError(err);
+            });
+
+            const request_config: AxiosRequestConfig = {headers: {Accept: "application/json;metadata=true"}};
+            axios.get<Metadata<T>>(url, request_config)
+            .then(result => {
+                setMetadata(result.data);
+                setStatusFlag("connected");
+                setUpdateFlag(Symbol(updateFlag_enum.FIRST));
+            })
+            .catch(err => {
+                throw handleError(err);
+            })
         })
-        .catch(() => {
-            return // error already gets reported by the GET method
-        });
-        get("", {wants_metadata: true})
-        .then(result => {
-            setMetadata(result as Metadata<T>);
-            setStatusFlag("connected");
-            setUpdateFlag(Symbol(updateFlag_enum.FIRST))
-        })
-        .catch(() => {
-            return
+        .catch(err => {
+            throw handleError(err);
         });
     }
 

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -124,11 +124,11 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
         }
     };
 
-    const put = async (data: ParamNode, param_path='') => {
+    const put = async <T = Parameter>(data: {[key: string]: T}, param_path='') => {
         // const url = [base_url, param_path].join("/"); // assumes param_path does not start with a slash
         console.debug(`PUT: ${base_url}/${param_path}, data: `, data);
         
-        let result: ParamNode = {};
+        let result: typeof data = {};
         let response: AxiosResponse<typeof result>;
 
         try {
@@ -267,10 +267,12 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
         });
     }
     
-    const mergeData = (newData: ParamNode, param_path: string) => {
-        const splitPath = param_path.split("/").slice(0, -1);
+    const mergeData = (newData: ParamTree, param_path: string) => {
+        const splitPath = param_path.replace(/\/$/, "").split("/");
+        const paramName = splitPath.pop()!;
+
         const tmpData = data.current;  // use tmpData as a copy of the Data that we can modify
-        let pointer: ParamNode[keyof ParamNode] = tmpData;  // pointer that can traverse down the nested data
+        let pointer: ParamTree = tmpData;  // pointer that can traverse down the nested data
 
         if(splitPath[0]) {
             splitPath.forEach((part_path) => {
@@ -280,12 +282,21 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
             });
         }
         // becasue pointer was a copy of tmpData, changes made to it will also be made to tmpData
+        if(isParamNode(newData)){
+            // const keys = Object.keys(newData);
+
+            if("value" in newData && Object.keys(newData).length == 1){
+                // test if merge data has only one key of "value". This likely means we're
+                // using Odin Control 2.0 and need to adjust to merge it into the larger tree
+                newData = {[paramName]: newData["value"]}
+            }
+        }
         Object.assign(pointer, newData);
         data.current = tmpData;
         setUpdateFlag(Symbol(updateFlag_enum.MERGED));
     }
     
-    return { data: data.current, metadata, error, loading: awaiting, updateFlag, status: statusFlag, get, put, post, remove, refreshData, mergeData}
+    return { data: data.current, metadata, error, loading: awaiting, updateFlag, status: statusFlag, apiVersion, get, put, post, remove, refreshData, mergeData}
 }
 
 export { useAdapterEndpoint, isParamNode, getValueFromPath };

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -310,11 +310,11 @@ export { useAdapterEndpoint, isParamNode, isMetadataValue, getValueFromPath };
 export type { AdapterEndpoint, Parameter, ParamNode, Metadata, ParamTree };
 
 /**
- * @deprecated This is the old name for this type and should be replaced with "Parameter"
+ * @deprecated This is the old name for this type and should be replaced with {@link ParamTree}
  */
 export type JSON = ParamTree
 
 /**
- * @deprecated This is the old name for this type, and should be replaced with "ParamNode"
+ * @deprecated This is the old name for this type, and should be replaced with {@link ParamNode}
  */
 export type NodeJSON = ParamNode

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
-import type { AdapterEndpoint, Metadata, Parameter, ParamNode, ParamTree, getConfig, status } from "./AdapterEndpoint.types";
+import type { AdapterEndpoint, Metadata, Parameter, ParamNode, ParamTree, getConfig, status, MetadataValue } from "./AdapterEndpoint.types";
 import { useError } from "../OdinErrorContext";
 
 // odin control 2.0 no longer uses an API Version.
@@ -17,6 +17,10 @@ enum updateFlag_enum {
 
 const isParamNode = (x: ParamTree): x is ParamNode => {
     return x !== null && typeof x === "object" && !Array.isArray(x);
+}
+
+const isMetadataValue = (x: Metadata): x is MetadataValue => {
+    return isParamNode(x) && "writeable" in x
 }
 
 /**
@@ -299,7 +303,7 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
     return { data: data.current, metadata, error, loading: awaiting, updateFlag, status: statusFlag, apiVersion, get, put, post, remove, refreshData, mergeData}
 }
 
-export { useAdapterEndpoint, isParamNode, getValueFromPath };
+export { useAdapterEndpoint, isParamNode, isMetadataValue, getValueFromPath };
 export type { AdapterEndpoint, Parameter, ParamNode, Metadata, ParamTree };
 
 /**

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -204,38 +204,41 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
         // discover Odin Control version (1.* or 2.*, changes what the full URL needs to be)
         let url = [endpoint_url, "api"].filter(Boolean).join("/");
         console.debug("Checking Odin Control Version");
-
+        let api_version = "";
         //can't use the get function of the endpoint yet, because we don't know if the base_url is correct
         // until we've worked out if we need the api "0.1" yet.
         axios.get<{api?: number}>(url)
         .then(result => {
-            const api_version = result.data?.api ? result.data.api.toString() : "";
-            
+            api_version = result.data?.api ? result.data.api.toString() : "";
+        })
+        .catch(() => {
+            // might just be CORS error from previous Odin Control version
+            //try and do the get stuff with the api_version 0.1?
+            // throw handleError(err);
+            console.debug("No response from checking version. Assuming <2.0.0");
+            api_version = "0.1";
+        })
+        .finally(() => {
             setApiVersion(api_version);
             url = [url, api_version, adapter].filter(Boolean).join("/");
             setBaseUrl(url);
-            
-            axios.get<T>(url)
-            .then(result => {
-                data.current = result.data;
-            })
-            .catch(err => {
-                throw handleError(err);
-            });
 
             const request_config: AxiosRequestConfig = {headers: {Accept: "application/json;metadata=true"}};
-            axios.get<Metadata<T>>(url, request_config)
-            .then(result => {
-                setMetadata(result.data);
+            // using Promise.all to ensure we set the trees and flags only when
+            // both requests have returned
+            Promise.all([
+                axios.get<T>(url),
+                axios.get<Metadata<T>>(url, request_config)
+            ]).then(([dataResult, metadataResult]) => {
+                data.current = dataResult.data;
+                setMetadata(metadataResult.data);
                 setStatusFlag("connected");
                 setUpdateFlag(Symbol(updateFlag_enum.FIRST));
             })
             .catch(err => {
                 throw handleError(err);
-            })
-        })
-        .catch(err => {
-            throw handleError(err);
+            });
+
         });
     }
 

--- a/lib/components/AdapterEndpoint/index.tsx
+++ b/lib/components/AdapterEndpoint/index.tsx
@@ -210,10 +210,10 @@ function useAdapterEndpoint<T extends ParamNode = ParamNode>(
             setApiVersion(api_version);
             url = [url, api_version, adapter].filter(Boolean).join("/");
             setBaseUrl(url);
-
-            axios.get(url)
+            
+            axios.get<T>(url)
             .then(result => {
-                data.current = result.data as T;
+                data.current = result.data;
             })
             .catch(err => {
                 throw handleError(err);

--- a/lib/components/OdinDoubleSlider/index.tsx
+++ b/lib/components/OdinDoubleSlider/index.tsx
@@ -6,14 +6,14 @@ import { OverlayTrigger, OverlayTriggerProps, Tooltip, InputGroup } from "react-
 import style from './styles.module.css'
 
 
-interface SliderProps {
+interface SliderProps extends ComponentPropsWithRef<"div">{
     min?: number;
     max?: number;
     value?: number[];
     step?: number;
     title?: string;
-    onChange?: React.ChangeEventHandler;
-    onKeyPress?: React.KeyboardEventHandler;
+    onChange?: React.ChangeEventHandler<DivRef>;
+    onMouseUp?: React.MouseEventHandler<HTMLInputElement>;
     showTooltip?: boolean;
     showMinMaxValues?: boolean;
     tooltipPosition?: OverlayTriggerProps["placement"];
@@ -44,22 +44,22 @@ const Div = (props: DivProps) => {
 }
 
 const OptionalOverlay = (props: OverlayTriggerProps) => {
-    const {show, children, ...leftoverProps} = props;
-    if(show) return <OverlayTrigger {...leftoverProps}>{children}</OverlayTrigger>
+    const { show, children, ...leftoverProps } = props;
+    if (show) return <OverlayTrigger {...leftoverProps}>{children}</OverlayTrigger>
     else return <>{children as React.ReactNode}</>
 
 }
 
 const OdinDoubleSlider: React.FC<SliderProps> = (props) => {
 
-    const {min=0, max=100, step=1, value=[min, max]} = props;
-    const {title, showTooltip=true, tooltipPosition="auto", disabled, showMinMaxValues=true} = props;
-    const {onChange, onKeyPress} = props;
+    const { min = 0, max = 100, step = 1, value = [min, max] } = props;
+    const { title, showTooltip = true, tooltipPosition = "auto", disabled, showMinMaxValues = true } = props;
+    const { onChange, onMouseUp } = props;
 
-    const [vals, changeVals] = useState<value_t>({low: value[0], high: value[1]});
+    const [vals, changeVals] = useState<value_t>({ low: value[0], high: value[1] });
 
     useEffect(() => {
-        changeVals({low: value[0], high: value[1]})
+        changeVals({ low: value[0], high: value[1] })
     }, [value[0], value[1]]);
 
     const divRef = useRef<DivRef>(null);
@@ -70,59 +70,31 @@ const OdinDoubleSlider: React.FC<SliderProps> = (props) => {
         // let otherVal = val;
         let newLow = vals.low;
         let newHigh = vals.high;
-        if(id == "left_slider"){
+        if (id == "left_slider") {
             newLow = val;
-            if(newLow >= newHigh){
+            if (newLow >= newHigh) {
                 newHigh = val;
             }
         }
-        else{
+        else {
             newHigh = val;
-            if(newHigh <= newLow){
+            if (newHigh <= newLow) {
                 newLow = val;
             }
         }
-        changeVals({low: newLow, high: newHigh});
+        changeVals({ low: newLow, high: newHigh });
 
-        if(onChange != null){
+        if (onChange != null) {
             // manually trigger the onChange event with the value from the two sliders
             const target = divRef.current!;
             target.value = [newLow, newHigh];
-            const newEvent: React.ChangeEvent = Object.assign(event, 
-            {
-               target: target,
-               nativeEvent: event.nativeEvent
-                
-
-            });
+            const newEvent: React.ChangeEvent<DivRef> = Object.assign(
+                event as unknown as React.ChangeEvent<DivRef>,
+                {
+                    target: target,
+                    nativeEvent: event.nativeEvent
+                });
             onChange(newEvent);
-        }
-    }
-
-    const onMouseUp: React.MouseEventHandler<HTMLInputElement> = (event) => {
-        if(onKeyPress != null){
-            // we gotta fake the Enter Key Press to allow this component to work with WithEndpoint
-            const eventDetails: KeyboardEventInit = {};
-            eventDetails.key = "Enter";
-            eventDetails.shiftKey = false;
-            const nativeEvent = new KeyboardEvent("keypress", eventDetails);
-            const newEvent: React.KeyboardEvent = Object.assign(event, 
-            {
-                target: divRef.current!,
-                nativeEvent: nativeEvent,
-                key: "Enter",
-                code: "Enter",
-                charCode: 13,
-                which: 13,
-                keyCode: 0,
-                locale: "undefined",
-                location: 0,
-                repeat: false
-
-            });
-            
-            onKeyPress(newEvent);
-
         }
     }
 
@@ -134,9 +106,9 @@ const OdinDoubleSlider: React.FC<SliderProps> = (props) => {
 
     const titleDiv = (
         <div className={style.dataList}>
-            {showMinMaxValues ? <InputGroup.Text>{min}</InputGroup.Text> : <div/>}
+            {showMinMaxValues ? <InputGroup.Text>{min}</InputGroup.Text> : <div />}
             {title != null ? <InputGroup.Text>{title}</InputGroup.Text> : <></>}
-            {showMinMaxValues ? <InputGroup.Text>{max}</InputGroup.Text> : <div/>}
+            {showMinMaxValues ? <InputGroup.Text>{max}</InputGroup.Text> : <div />}
         </div>
     )
     return (
@@ -147,11 +119,11 @@ const OdinDoubleSlider: React.FC<SliderProps> = (props) => {
                     <input disabled={disabled} type="range" id="left_slider"
                         className={`${style.input} ${style.left}`}
                         onChange={onSlide} onMouseUp={onMouseUp}
-                        min={min} max={max} step={step} value={vals.low}/>
+                        min={min} max={max} step={step} value={vals.low} />
                     <input disabled={disabled} type="range" id="right_slider"
-                    className={`${style.input} ${style.right}`}
+                        className={`${style.input} ${style.right}`}
                         onChange={onSlide} onMouseUp={onMouseUp}
-                        min={min} max={max} step={step} value={vals.high}/>
+                        min={min} max={max} step={step} value={vals.high} />
                 </Div>
             </OptionalOverlay>
         </div>

--- a/lib/components/OdinErrorContext/index.tsx
+++ b/lib/components/OdinErrorContext/index.tsx
@@ -41,7 +41,7 @@ const errorsReducer = (errors: OdinError[], action: ErrorAction) => {
     const err = action.error;
     switch(action.type){
         case ErrorActionType.ADD:
-            if(err === undefined){
+            { if(err === undefined){
                 console.error("Error not provided to setError method");
                 return errors;
             }
@@ -58,7 +58,7 @@ const errorsReducer = (errors: OdinError[], action: ErrorAction) => {
                 }
                 return old_err;
             }) : [newError];
-            return newErrorList;
+            return newErrorList; }
         case ErrorActionType.REMOVE:
             if(err === undefined){
                 console.error("Error not provided to clearError method");

--- a/lib/components/OdinEventLog/index.tsx
+++ b/lib/components/OdinEventLog/index.tsx
@@ -1,5 +1,5 @@
 import { TitleCard } from "../TitleCard";
-import type {AdapterEndpoint, NodeJSON} from "../AdapterEndpoint";
+import type {AdapterEndpoint, ParamNode} from "../AdapterEndpoint";
 import {Row, Col } from 'react-bootstrap';
 import { ToggleButtonGroup, ToggleButton, Form, InputGroup, Button, OverlayTrigger, Popover } from "react-bootstrap";
 
@@ -9,7 +9,7 @@ import { Filter, Clock, CalendarEvent, ArrowBarDown } from "react-bootstrap-icon
 import style from './styles.module.css';
 import React, { useEffect, useState, CSSProperties, useRef, useMemo, useCallback } from "react";
 
-interface Log extends NodeJSON {
+interface Log extends ParamNode {
     level?: "debug" | "info" | "warning" | "error" | "critical";
     timestamp: string;
     message: string;

--- a/lib/components/OdinLiveView/index.tsx
+++ b/lib/components/OdinLiveView/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { AdapterEndpoint as AdapterEndpoint, NodeJSON} from '../AdapterEndpoint';
+import type { AdapterEndpoint as AdapterEndpoint, ParamNode} from '../AdapterEndpoint';
 import { getValueFromPath } from '../AdapterEndpoint';
 
 import React, { useCallback, useEffect, useState, useRef } from 'react';
@@ -31,7 +31,7 @@ interface ZoomableImageProps {
 
 }
 
-interface LiveViewParam extends NodeJSON {
+interface LiveViewParam extends ParamNode {
     frame: {
         frame_num: number;
     }

--- a/lib/components/OdinTable/index.tsx
+++ b/lib/components/OdinTable/index.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 import type { CSSProperties } from "react";
 import { Table } from "react-bootstrap";
-import { JSON, NodeJSON } from "../AdapterEndpoint";
+import { ParamTree, ParamNode } from "../AdapterEndpoint";
 
 interface OdinTableProps extends React.ComponentProps<typeof Table> {
     columns: {[key: string]: string};
@@ -10,15 +10,15 @@ interface OdinTableProps extends React.ComponentProps<typeof Table> {
 }
 
 interface OdinTableRowProps {
-    row: {[key: string] : Exclude<JSON, NodeJSON | JSON[]>};
+    row: {[key: string] : Exclude<ParamTree, ParamNode | ParamTree[]>};
 }
 
-interface OdinTableContext_t {
+interface OdinTableContext {
     column_keys: string[];
     widths: {[key: string]: CSSProperties["width"]};
 }
 
-const OdinTableContext = createContext<OdinTableContext_t>({column_keys: [], widths: {}});
+const OdinTableContext = createContext<OdinTableContext>({column_keys: [], widths: {}});
 
 const OdinTableRow: React.FC<OdinTableRowProps> = (props) => {
     const ctx = useContext(OdinTableContext);

--- a/lib/components/ParamController/index.tsx
+++ b/lib/components/ParamController/index.tsx
@@ -1,235 +1,166 @@
-import { AdapterEndpoint, getValueFromPath, isParamNode } from "../AdapterEndpoint";
-import type { NodeJSON, JSON } from "../AdapterEndpoint";
-import { trimByChar, WithEndpoint } from "../WithEndpoint";
+import type { Metadata, ParamTree, Parameter } from "../AdapterEndpoint";
+import { AdapterEndpoint, getValueFromPath, isMetadataValue, isParamNode } from "../AdapterEndpoint";
+import { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput } from "../WithEndpoint";
 
-import { useMemo, useState } from "react";
-import { Button, Form, InputGroup, OverlayTrigger, Tooltip, DropdownButton, Dropdown, Table, Card, Collapse } from "react-bootstrap";
+import {  useState } from "react";
+import { Card, Collapse, Dropdown, InputGroup, OverlayTrigger, Table, Tooltip } from "react-bootstrap";
 
 import type { PropsWithChildren, ReactNode } from "react";
 
-import Style from './styles.module.css'
+import Style from './styles.module.css';
 
 interface CollapseableCardProps extends PropsWithChildren {
-  header: ReactNode;
-  defaultOpen?: boolean;
+    header: ReactNode;
+    defaultOpen?: boolean;
 }
 
 const CollapseableCard: React.FC<CollapseableCardProps> = (
-  { header, defaultOpen = true, children }
+    { header, defaultOpen = true, children }
 ) => {
 
-  const [open, setOpen] = useState(defaultOpen);
+    const [open, setOpen] = useState(defaultOpen);
 
-  return (
-    <Card>
-      <Card.Header onClick={() => setOpen(oldVal => !oldVal)} className={Style.collapseHeader}>
-        {header}
-      </Card.Header>
-      <Collapse in={open}>
-        {/* div required for smooth transition */}
-        <div>
-          <Card.Body>
-            {children}
-          </Card.Body>
-        </div>
-      </Collapse>
-    </Card>
-  );
+    return (
+        <Card>
+            <Card.Header onClick={() => setOpen(oldVal => !oldVal)} className={Style.collapseHeader}>
+                {header}
+            </Card.Header>
+            <Collapse in={open}>
+                {/* div required for smooth transition */}
+                <div>
+                    <Card.Body>
+                        {children}
+                    </Card.Body>
+                </div>
+            </Collapse>
+        </Card>
+    );
 }
 
 
 interface ParamControllerProps {
-  endpoint: AdapterEndpoint;
-  path?: string;
-  title?: string;
+    endpoint: AdapterEndpoint;
+    path?: string;
+    title?: string;
 }
 
-type ValType = "string" | "number" | "boolean" | "null" | "list" | "dict";
-
-const EndpointInput = WithEndpoint(Form.Control);
-const EndpointCheckbox = WithEndpoint(Form.Switch);
-const EndpointButton = WithEndpoint(Button);
-const EndpointDropdown = WithEndpoint(DropdownButton);
 
 const ParamController: React.FC<ParamControllerProps> = (
-  { endpoint, path = "", title }
+    { endpoint, path = "", title }
 ) => {
 
-  // const param: JSON = getValueFromPath(endpoint.data, path);
+    // const param: JSON = getValueFromPath(endpoint.data, path);
+    const metadata: Metadata = getValueFromPath(endpoint.metadata, path)!;
+    const param: ParamTree = getValueFromPath(endpoint.data, path)!;
 
-  const name: string = useMemo(() => {
-    if (title) return title;
-    const metadata = getValueFromPath<JSON>(endpoint.metadata, path);
-    if(isParamNode(metadata) && "name" in metadata){
-      return metadata.name as string;
-    }
-
-    let valName = trimByChar(path, "/");
-    if (valName.includes("/")) {
-      valName = valName.split(/\/(?!.*\/)(.*)/, 2).pop()!;
-    }
-    return valName;
-  }, [path]);
-
-  const { param, ParamType, metadata } = useMemo(() => {
-    const metadata = getValueFromPath<JSON>(endpoint.metadata, path);
-    const param: JSON = getValueFromPath<JSON>(endpoint.data, path);
-    let type: ValType;
-
-    const rawType = isParamNode(metadata) && "writeable" in metadata ?
-      metadata.type as string : typeof param;
+    const name = title ?? (isMetadataValue(metadata) && metadata.name ?
+        metadata.name : path.replace(/\/$/, "").split("/").pop() ?? "unknown");
 
 
-    switch (rawType) {
-      case "int":
-      case "float":
-      case "complex":
-      case "bigint":
-      case "number":
-        type = "number";
-        break;
-      case "list":
-      case "tuple":
-      case "range":
-        type = "list";
-        break;
-      case "bool":
-      case "boolean":
-        type = "boolean";
-        break;
-      case "str":
-      case "string":
-        type = "string";
-        break;
-      case "NoneType":
-      case "function":
-      case "symbol":
-      case "undefined":
-        type = "null";
-        break;
-      case "object":
-        switch (true) {
-          case param instanceof Array:
-            type = "list";
-            break;
-          case param == null:
-            type = "null";
-            break;
-          default:
-            type = "dict"
-            break;
-        }
-        break;
-      default:
-        type = rawType as ValType;
-        break;
-    }
-
-    return { param, ParamType: type, metadata };
-
-  },
-    [endpoint.metadata, endpoint.updateFlag, path]);
-
-
-  if (isParamNode(metadata) && "allowed_values" in metadata) {
-    type selectionType = string | number;
-    return (
-      <InputGroup>
-        <InputGroup.Text>{name}</InputGroup.Text>
-        <EndpointDropdown endpoint={endpoint} fullpath={path} event_type="select"
-          title={param || "Unknown"}>
-          {(metadata.allowed_values as JSON[]).map(
-            (selection, index) => (
-              <Dropdown.Item eventKey={selection as selectionType} key={index} active={selection == param}>
-                {selection as selectionType}
-              </Dropdown.Item>
-            )
-          )}
-        </EndpointDropdown>
-      </InputGroup>
-    )
-  } else {
-
-    switch (ParamType) {
-      case "dict": // recursily create more Param Controller controls within a TitleCard
+    if (isMetadataValue(metadata) && metadata.allowed_values && !isParamNode(param)) {
+        //we have a value with specific allowed values. Create a dropdown
         return (
-          <CollapseableCard header={name}>
-            <div className="d-grid gap-2">
-              {Object.keys(param as NodeJSON).map((val, index) => (
-                <ParamController
-                  key={index}
-                  endpoint={endpoint}
-                  path={path ? [path, val].join("/") : val}
-                />
-              ))}
-            </div>
-          </CollapseableCard>
-        )
-      case "boolean":  // Toggle Switch
-        return (
-          <InputGroup>
-            <InputGroup.Text>{name}</InputGroup.Text>
-            <InputGroup.Text>
-              <EndpointCheckbox endpoint={endpoint} fullpath={path}
-                type="switch" />
-            </InputGroup.Text>
-          </InputGroup>
-        )
-      case "string":
-      case "number":
-        return (
-          <InputGroup>
-            <InputGroup.Text>{name}</InputGroup.Text>
-            <EndpointInput endpoint={endpoint} fullpath={path}
-              type={ParamType == "number" ? "number" : undefined}
-            />
-          </InputGroup>
-        )
-      case "null":
-        return (
-          <OverlayTrigger overlay={<Tooltip id={name}>Value assumed to be True</Tooltip>}>
-            <EndpointButton endpoint={endpoint} fullpath={path} value={true}>
-              {name}
-            </EndpointButton>
-          </OverlayTrigger>
-        )
-      case "list":  // render a table? do we need to worry about if its editable? I dont think list Params are editable
-        return (
-          <CollapseableCard header={name}>
-            <Table striped bordered hover>
-              <thead>
-                <tr>
-                  <th>#</th>
-                  <th colSpan={1000}>{name}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(param as JSON[]).map(
-                  (val, index) => (
-                    <tr>
-                      <td>{index}</td>
-                      {typeof val == "object" && val != null ?
-                        Object.entries(val).map(
-                          ([key, mapVal]) => (
-                            <td id={key}>{`${key}: ${mapVal}`}</td>
-                          )
+            <InputGroup>
+                <InputGroup.Text>{name}</InputGroup.Text>
+                <EndpointDropdown endpoint={endpoint} fullpath={path}
+                    title={String(param) || "Unknown"}>
+                    {(metadata.allowed_values as Parameter[]).map(
+                        (selection, index) => (
+                            <Dropdown.Item eventKey={selection as string | number} key={index} active={selection == param}>
+                                {selection as string | number}
+                            </Dropdown.Item>
                         )
-                        :
-                        <td>{String(val)}</td>
-                      }
-                    </tr>
-                  )
-                )}
-              </tbody>
-            </Table>
-          </CollapseableCard>
+                    )}
+                </EndpointDropdown>
+            </InputGroup>
         )
-      default:
-        return (
-          <p>{param as string | number}</p>
-        )
+    } else {
+
+        switch (typeof param) {
+            case "object":
+                switch (true) {
+                    case param == null:
+                        return (
+                            <OverlayTrigger overlay={<Tooltip id={name}>Value assumed to be True</Tooltip>}>
+                                <EndpointButton endpoint={endpoint} fullpath={path} value={true}>
+                                    {name}
+                                </EndpointButton>
+                            </OverlayTrigger>
+                        )
+                    case param instanceof Array:
+
+                        return (
+                            <CollapseableCard header={name}>
+                                <Table striped bordered hover>
+                                    <thead>
+                                        <tr>
+                                            <th>#</th>
+                                            <th colSpan={1000}>{name}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {(param as Parameter[]).map(
+                                            (val, index) => (
+                                                <tr>
+                                                    <td>{index}</td>
+                                                    {typeof val == "object" && val != null ?
+                                                        Object.entries(val).map(
+                                                            ([key, mapVal]) => (
+                                                                <td id={key}>{`${key}: ${mapVal}`}</td>
+                                                            )
+                                                        )
+                                                        :
+                                                        <td>{String(val)}</td>
+                                                    }
+                                                </tr>
+                                            )
+                                        )}
+                                    </tbody>
+                                </Table>
+                            </CollapseableCard>
+                        )
+                    case isParamNode(param):
+                    default:
+                        return (
+                            <CollapseableCard header={name}>
+                                <div className="d-grid gap-2">
+                                    {Object.keys(param).map((val, index) => (
+                                        <ParamController
+                                            key={index}
+                                            endpoint={endpoint}
+                                            path={path ? [path, val].join("/") : val}
+                                        />
+                                    ))}
+                                </div>
+                            </CollapseableCard>
+                        )
+                }
+            case "boolean":  // Toggle Switch
+                return (
+                    <InputGroup>
+                        <InputGroup.Text>{name}</InputGroup.Text>
+                        <InputGroup.Text>
+                            <EndpointCheckbox endpoint={endpoint} fullpath={path}
+                                type="switch" />
+                        </InputGroup.Text>
+                    </InputGroup>
+                )
+            case "string":
+            case "number":
+                return (
+                    <InputGroup>
+                        <InputGroup.Text>{name}</InputGroup.Text>
+                        <EndpointInput endpoint={endpoint} fullpath={path}
+                            type={typeof param == "number" ? "number" : undefined}
+                        />
+                    </InputGroup>
+                )
+            default:
+                return (
+                    <p>{param as string | number}</p>
+                )
+        }
     }
-  }
 
 }
 

--- a/lib/components/WithEndpoint/EndpointButton.tsx
+++ b/lib/components/WithEndpoint/EndpointButton.tsx
@@ -1,0 +1,59 @@
+import type { ButtonProps } from "react-bootstrap";
+import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
+import { Button } from "react-bootstrap";
+import { getValueFromPath } from "../AdapterEndpoint";
+
+import { sendRequest } from "./util";
+import type { EndpointProps } from "./util";
+import { useTransition } from "react";
+
+
+type EndpointButtonProps<PreArgs extends unknown[], PostArgs extends unknown[]> = 
+    EndpointProps<PreArgs, PostArgs> & Omit<ButtonProps, keyof EndpointProps<PreArgs, PostArgs>>;
+
+
+
+const EndpointButton = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args,
+        ...rest }: EndpointButtonProps<PreArgs, PostArgs>
+) => {
+    const compVal = value ?? getValueFromPath(endpoint.data, fullpath);
+    const metaData: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
+                                        ?? {value: compVal, type: "int", writeable: true};
+
+    const [isPending, startPendingTransition] = useTransition();
+    
+    const disable = disabled || isPending || endpoint.loading || !(metaData.writeable ?? true);
+
+    const requestHandler = () => {
+        startPendingTransition(async () => {
+            
+            
+            pre_method?.(...(pre_args ?? []) as PreArgs);
+        
+
+            sendRequest(compVal, endpoint, fullpath)
+            .then(() => {
+                
+                post_method?.(...(post_args ?? []) as PostArgs);
+                
+            });
+        })
+    }
+    
+    const onClickHandler = (event: React.MouseEvent) => {
+        console.debug(fullpath, event);
+
+        requestHandler();
+    }
+
+    return (
+        <Button onClick={onClickHandler} {...rest} disabled={disable}>
+            {rest.children}
+        </Button>
+    )
+}
+
+export { EndpointButton };

--- a/lib/components/WithEndpoint/EndpointButton.tsx
+++ b/lib/components/WithEndpoint/EndpointButton.tsx
@@ -8,21 +8,19 @@ type EndpointButtonProps<PreArgs extends unknown[], PostArgs extends unknown[]> 
     EndpointProps<PreArgs, PostArgs> & Omit<ButtonProps, keyof EndpointProps<PreArgs, PostArgs>>;
 
 const EndpointButton = <PreArgs extends unknown[], PostArgs extends unknown[]>(
-    props: EndpointButtonProps<PreArgs, PostArgs>
-) => {
-    const { endpoint, fullpath, value, disabled,
+    { endpoint, fullpath, value, disabled,
         pre_method, pre_args,
         post_method, post_args,
-        ...rest } = props;
-
-
+        ...rest }: EndpointButtonProps<PreArgs, PostArgs>
+) => {
+    
     const { requestHandler, disable } = useRequestHandler({
         endpoint, fullpath, value, disabled,
         pre_method, pre_args,
         post_method, post_args
     });
 
-    const onClickHandler = (event: React.MouseEvent) => {
+    const onClickHandler: ButtonProps["onClick"] = (event) => {
         console.debug(fullpath, event);
 
         requestHandler(value);

--- a/lib/components/WithEndpoint/EndpointButton.tsx
+++ b/lib/components/WithEndpoint/EndpointButton.tsx
@@ -1,52 +1,31 @@
 import type { ButtonProps } from "react-bootstrap";
-import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { Button } from "react-bootstrap";
-import { getValueFromPath } from "../AdapterEndpoint";
 
-import { sendRequest } from "./util";
 import type { EndpointProps } from "./util";
-import { useTransition } from "react";
+import { useRequestHandler } from "./util";
 
-
-type EndpointButtonProps<PreArgs extends unknown[], PostArgs extends unknown[]> = 
+type EndpointButtonProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
     EndpointProps<PreArgs, PostArgs> & Omit<ButtonProps, keyof EndpointProps<PreArgs, PostArgs>>;
 
-
-
 const EndpointButton = <PreArgs extends unknown[], PostArgs extends unknown[]>(
-    { endpoint, fullpath, value, disabled,
+    props: EndpointButtonProps<PreArgs, PostArgs>
+) => {
+    const { endpoint, fullpath, value, disabled,
         pre_method, pre_args,
         post_method, post_args,
-        ...rest }: EndpointButtonProps<PreArgs, PostArgs>
-) => {
-    const compVal = value ?? getValueFromPath(endpoint.data, fullpath);
-    const metaData: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
-                                        ?? {value: compVal, type: "int", writeable: true};
+        ...rest } = props;
 
-    const [isPending, startPendingTransition] = useTransition();
-    
-    const disable = disabled || isPending || endpoint.loading || !(metaData.writeable ?? true);
 
-    const requestHandler = () => {
-        startPendingTransition(async () => {
-            
-            
-            pre_method?.(...(pre_args ?? []) as PreArgs);
-        
+    const { requestHandler, disable } = useRequestHandler({
+        endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args
+    });
 
-            sendRequest(compVal, endpoint, fullpath)
-            .then(() => {
-                
-                post_method?.(...(post_args ?? []) as PostArgs);
-                
-            });
-        })
-    }
-    
     const onClickHandler = (event: React.MouseEvent) => {
         console.debug(fullpath, event);
 
-        requestHandler();
+        requestHandler(value);
     }
 
     return (

--- a/lib/components/WithEndpoint/EndpointCheckbox.tsx
+++ b/lib/components/WithEndpoint/EndpointCheckbox.tsx
@@ -1,0 +1,44 @@
+import type { FormCheckProps } from "react-bootstrap";
+import { FormCheck } from "react-bootstrap";
+
+import type { EndpointProps } from "./util";
+import { useRequestHandler } from "./util";
+
+type EndpointCheckboxProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    EndpointProps<PreArgs, PostArgs> & Omit<FormCheckProps, keyof EndpointProps<PreArgs, PostArgs>>;
+
+
+const EndpointCheckbox = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args,
+        ...rest }: EndpointCheckboxProps<PreArgs, PostArgs>
+) => {
+
+    const { requestHandler, data, disable } = useRequestHandler({
+        endpoint, fullpath, value: undefined, disabled,
+        pre_method, pre_args,
+        post_method, post_args
+    });
+
+    const checked = typeof value !== "undefined" ? value == data : Boolean(data);
+
+
+    const onChangeHandler: FormCheckProps["onChange"] = (event) => {
+        console.debug(fullpath, event);
+        
+        const target = event.target;
+        const checked = target.checked;
+
+        requestHandler(value ?? checked);
+    }
+
+
+    return (
+        <FormCheck onChange={onChangeHandler} {...rest} disabled={disable} checked={checked}>
+            {rest.children}
+        </FormCheck>
+    )
+}
+
+export { EndpointCheckbox };

--- a/lib/components/WithEndpoint/EndpointDoubleSlider.tsx
+++ b/lib/components/WithEndpoint/EndpointDoubleSlider.tsx
@@ -1,0 +1,52 @@
+import { type EndpointProps, useRequestHandler } from "./util";
+
+import { OdinDoubleSlider } from "../OdinDoubleSlider";
+import { ComponentProps, useRef, useState, useEffect } from "react";
+import { getValueFromPath } from "../AdapterEndpoint";
+
+type EndpointDoubleSliderProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    Omit<EndpointProps<PreArgs, PostArgs>, "value"> & ComponentProps<typeof OdinDoubleSlider>;
+
+
+const EndpointDoubleSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled, min, max,
+        pre_method, pre_args,
+        post_method, post_args,
+        ...rest}: EndpointDoubleSliderProps<PreArgs, PostArgs>
+    ) => {
+
+        const {requestHandler, data, disable}  = useRequestHandler({
+            endpoint, fullpath, value, disabled,
+            pre_method, pre_args, post_method, post_args
+        });
+
+        const [compVal, changeCompVal] = useState<ComponentProps<typeof OdinDoubleSlider>["value"]>([0, 100]);
+        const component = useRef<HTMLDivElement>(null);
+        const onChange: ComponentProps<typeof OdinDoubleSlider>["onChange"] = (event) => {
+            const target = event.target;
+
+            changeCompVal(target.value);
+        }
+
+        const onMouseUp: ComponentProps<typeof OdinDoubleSlider>['onMouseUp'] = (event) => {
+            console.debug(event);
+            requestHandler(compVal);
+        }
+
+        useEffect(() => {
+            const newVal = getValueFromPath<number[]>(endpoint.data, fullpath);
+            if(typeof newVal !== "undefined" && !component.current?.contains(document.activeElement)){
+                changeCompVal(newVal);
+            }
+        }, [endpoint.updateFlag, data]);
+
+
+
+        return (
+            <OdinDoubleSlider ref={component} min={min} max={max} value={compVal} 
+                onChange={onChange} onMouseUp={onMouseUp} disabled={disable} {...rest}/>
+        )
+
+    }
+
+    export {EndpointDoubleSlider};

--- a/lib/components/WithEndpoint/EndpointDropdown.tsx
+++ b/lib/components/WithEndpoint/EndpointDropdown.tsx
@@ -1,0 +1,37 @@
+import type { DropdownButtonProps } from "react-bootstrap";
+import { DropdownButton } from "react-bootstrap";
+import type { EndpointProps } from "./util";
+import { useRequestHandler } from "./util";
+
+type EndpointDropdownProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    EndpointProps<PreArgs, PostArgs> & Omit<DropdownButtonProps, keyof EndpointProps<PreArgs, PostArgs> | "title">
+    & {title?: React.ReactNode}
+
+const EndpointDropdown = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args,
+        title, ...rest }: EndpointDropdownProps<PreArgs, PostArgs>
+) => {
+
+    const { requestHandler, data, disable } = useRequestHandler({
+        endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args
+    });
+
+
+    const onSelectHandler: DropdownButtonProps["onSelect"] = (eventKey, event) => {
+        console.debug(fullpath, event, eventKey);
+
+        requestHandler(eventKey);
+    }
+
+    return (
+        <DropdownButton title={title ?? data as string} onSelect={onSelectHandler} disabled={disable} {...rest}>
+            {rest.children}
+        </DropdownButton>
+    )
+} 
+
+export { EndpointDropdown };

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -27,7 +27,7 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
     const metaData: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
                                         ?? {value: endVal, type: "str", writeable: true};
     const [compVal, changeCompVal] = useState<FormControlProps['value']>("");
-    const [editing, setEditing] = useState<boolean>(false);
+    const [editing, setEditing] = useState(false);
     
     const compMin = min ?? metaData.min;
     const compMax = max ?? metaData.max;

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -1,10 +1,10 @@
 
 import { Form } from 'react-bootstrap';
 import type { FormControlProps } from 'react-bootstrap';
-import { sendRequest, type EndpointProps } from './util';
+import { useRequestHandler, type EndpointProps } from './util';
 import type { MetadataValue } from '../AdapterEndpoint/AdapterEndpoint.types';
 import { getValueFromPath } from '../AdapterEndpoint';
-import { CSSProperties, useEffect, useRef, useState, useTransition } from 'react';
+import { CSSProperties, useEffect, useRef, useState } from 'react';
 
 
 type EndpointInputProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
@@ -18,11 +18,17 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
         ...rest }: EndpointInputProps<PreArgs, PostArgs>
 ) => {
 
-    const endVal = value ?? getValueFromPath(endpoint.data, fullpath);
+    const {requestHandler, data: endVal, disable} = useRequestHandler({
+        endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args
+    });
+
     const metaData: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
                                         ?? {value: endVal, type: "str", writeable: true};
     const [compVal, changeCompVal] = useState<FormControlProps['value']>("");
     const [editing, setEditing] = useState<boolean>(false);
+    
     const compMin = min ?? metaData.min;
     const compMax = max ?? metaData.max;
 
@@ -31,10 +37,6 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
     const type: FormControlProps["type"] = rest.type ??
         ["int", "float", "complex"].includes(metaData.type) ? "number"
             : typeof endVal === "number" ? "number" : "";
-
-    const [isPending, startPendingTransition] = useTransition();
-
-    const disable = disabled || isPending || endpoint.loading || !(metaData.writeable ?? true);
 
     const style: CSSProperties = editing ? {backgroundColor: "var(--bs-highlight-bg)"} : {};
 
@@ -49,31 +51,17 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
     const onEnterHandler: FormControlProps["onKeyUp"] = (event) => {
         if(event.key === "Enter" && !event.shiftKey) {
             console.debug(fullpath, event);
-            requestHandler();
+            requestHandler(compVal);
             setEditing(false);
         }
     }
-
-    const requestHandler = () => {
-        startPendingTransition(async () => {
-
-            pre_method?.(...(pre_args ?? []) as PreArgs);
-
-            sendRequest(compVal, endpoint, fullpath)
-            .then(() => {
-
-                post_method?.(...(post_args ?? []) as PostArgs);
-            });
-        });
-    }
-
 
     useEffect(() => {
         //Endpoint Value changed, update component value if need be.
         const newVal = getValueFromPath<FormControlProps["value"]>(endpoint.data, fullpath);
 
         // check if the component is not currently active
-        if(document.activeElement !== component.current && !editing){
+        if(document.activeElement !== component.current && !editing && typeof newVal !== "undefined"){
             changeCompVal(newVal);
         }
 

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -24,18 +24,17 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
         post_method, post_args
     });
 
-    const metaData: MetadataValue = getValueFromPath(endpoint.metadata, fullpath)
-                                        ?? {value: endVal, type: "str", writeable: true};
+    const metaData: MetadataValue | undefined = getValueFromPath(endpoint.metadata, fullpath);
     const [compVal, changeCompVal] = useState<FormControlProps['value']>("");
     const [editing, setEditing] = useState(false);
     
-    const compMin = min ?? metaData.min;
-    const compMax = max ?? metaData.max;
+    const compMin = min ?? metaData?.min;
+    const compMax = max ?? metaData?.max;
 
     const component = useRef<HTMLInputElement>(null);
 
     const type: FormControlProps["type"] = rest.type ??
-        ["int", "float", "complex"].includes(metaData.type) ? "number"
+        ["int", "float", "complex"].includes(metaData?.type ?? "") ? "number"
             : typeof endVal === "number" ? "number" : "";
 
     const style: CSSProperties = editing ? {backgroundColor: "var(--bs-highlight-bg)"} : {};

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -1,0 +1,88 @@
+
+import { Form } from 'react-bootstrap';
+import type { FormControlProps } from 'react-bootstrap';
+import { sendRequest, type EndpointProps } from './util';
+import type { MetadataValue } from '../AdapterEndpoint/AdapterEndpoint.types';
+import { getValueFromPath } from '../AdapterEndpoint';
+import { CSSProperties, useEffect, useRef, useState, useTransition } from 'react';
+
+
+type EndpointInputProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    Omit<EndpointProps<PreArgs, PostArgs>, "value"> & Omit<FormControlProps, keyof Omit<EndpointProps<PreArgs, PostArgs>, "value">>;
+
+
+const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled, min, max,
+        pre_method, pre_args,
+        post_method, post_args,
+        ...rest }: EndpointInputProps<PreArgs, PostArgs>
+) => {
+
+    const endVal = value ?? getValueFromPath(endpoint.data, fullpath);
+    const metaData: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
+                                        ?? {value: endVal, type: "str", writeable: true};
+    const [compVal, changeCompVal] = useState<FormControlProps['value']>("");
+    const [editing, setEditing] = useState<boolean>(false);
+    const compMin = min ?? metaData.min;
+    const compMax = max ?? metaData.max;
+
+    const component = useRef<HTMLInputElement>(null);
+
+    const type: FormControlProps["type"] = rest.type ??
+        ["int", "float", "complex"].includes(metaData.type) ? "number"
+            : typeof endVal === "number" ? "number" : "";
+
+    const [isPending, startPendingTransition] = useTransition();
+
+    const disable = disabled || isPending || endpoint.loading || !(metaData.writeable ?? true);
+
+    const style: CSSProperties = editing ? {backgroundColor: "var(--bs-highlight-bg)"} : {};
+
+    const onChangeHandler: FormControlProps["onChange"] = (event) => {
+        const target = event.target;
+        const val = type == "number" ? Number(target.value) : target.value;
+
+        changeCompVal(val);
+        setEditing(!(val == endVal));
+    }
+
+    const onEnterHandler: FormControlProps["onKeyUp"] = (event) => {
+        if(event.key === "Enter" && !event.shiftKey) {
+            console.debug(fullpath, event);
+            requestHandler();
+            setEditing(false);
+        }
+    }
+
+    const requestHandler = () => {
+        startPendingTransition(async () => {
+
+            pre_method?.(...(pre_args ?? []) as PreArgs);
+
+            sendRequest(compVal, endpoint, fullpath)
+            .then(() => {
+
+                post_method?.(...(post_args ?? []) as PostArgs);
+            });
+        });
+    }
+
+
+    useEffect(() => {
+        //Endpoint Value changed, update component value if need be.
+        const newVal = getValueFromPath<FormControlProps["value"]>(endpoint.data, fullpath);
+
+        // check if the component is not currently active
+        if(document.activeElement !== component.current && !editing){
+            changeCompVal(newVal);
+        }
+
+    }, [endpoint.updateFlag, endVal]);
+
+    return (
+        <Form.Control ref={component} onChange={onChangeHandler} onKeyUp={onEnterHandler} value={compVal}
+            min={compMin} max={compMax} disabled={disable} type={type} {...rest} style={style}/>
+    )
+}
+
+export { EndpointInput };

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -24,7 +24,7 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
         post_method, post_args
     });
 
-    const metaData: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
+    const metaData: MetadataValue = getValueFromPath(endpoint.metadata, fullpath)
                                         ?? {value: endVal, type: "str", writeable: true};
     const [compVal, changeCompVal] = useState<FormControlProps['value']>("");
     const [editing, setEditing] = useState(false);

--- a/lib/components/WithEndpoint/EndpointSlider.tsx
+++ b/lib/components/WithEndpoint/EndpointSlider.tsx
@@ -30,12 +30,12 @@ const EndpointSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
 
     const onChange: FormRangeProps["onChange"] = (event) => {
         const target = event.target;
-        changeCompVal(Number(target.value))
+        changeCompVal(target.valueAsNumber);
     }
     const onMouseUp: FormRangeProps["onMouseUp"] = (event) => {
         const target = event.target as HTMLInputElement;
-        changeCompVal(Number(target.value));
-        requestHandler(target.value);
+        changeCompVal(target.valueAsNumber);
+        requestHandler(target.valueAsNumber);
     }
 
     useEffect(() => {

--- a/lib/components/WithEndpoint/EndpointSlider.tsx
+++ b/lib/components/WithEndpoint/EndpointSlider.tsx
@@ -1,0 +1,44 @@
+import FormRange from "react-bootstrap/FormRange";
+import type { FormRangeProps } from "react-bootstrap/FormRange";
+import { EndpointProps, useRequestHandler } from "./util";
+import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
+import { getValueFromPath } from "../AdapterEndpoint";
+import { useState } from "react";
+
+type EndpointRangeProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    EndpointProps<PreArgs, PostArgs> & FormRangeProps;
+
+
+const EndpointSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled, min, max,
+        pre_method, pre_args,
+        post_method, post_args,
+        ...rest}: EndpointRangeProps<PreArgs, PostArgs>
+) => {
+
+    const {requestHandler, disable}  = useRequestHandler({
+        endpoint, fullpath, value, disabled,
+        pre_method, pre_args, post_method, post_args
+    });
+
+    const [compVal, changeCompVal] = useState(0);
+    const metadata: MetadataValue| undefined = getValueFromPath(endpoint.metadata, fullpath);
+    const compMin = min ?? metadata?.min;
+    const compMax = max ?? metadata?.max;
+
+    const onChange: FormRangeProps["onChange"] = (event) => {
+        const target = event.target;
+        changeCompVal(Number(target.value))
+    }
+    const onMouseUp: FormRangeProps["onMouseUp"] = (event) => {
+        const target = event.target as HTMLInputElement;
+        requestHandler(target.value);
+    }
+
+    return (
+        <FormRange min={compMin} max={compMax} disabled={disable}
+            onMouseUp={onMouseUp} onChange={onChange} value={compVal} {...rest}/>
+    )
+}
+
+export { EndpointSlider };

--- a/lib/components/WithEndpoint/EndpointSlider.tsx
+++ b/lib/components/WithEndpoint/EndpointSlider.tsx
@@ -3,7 +3,7 @@ import type { FormRangeProps } from "react-bootstrap/FormRange";
 import { EndpointProps, useRequestHandler } from "./util";
 import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { getValueFromPath } from "../AdapterEndpoint";
-import { useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 type EndpointRangeProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
     EndpointProps<PreArgs, PostArgs> & FormRangeProps;
@@ -16,7 +16,7 @@ const EndpointSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
         ...rest}: EndpointRangeProps<PreArgs, PostArgs>
 ) => {
 
-    const {requestHandler, disable}  = useRequestHandler({
+    const {requestHandler, data, disable}  = useRequestHandler({
         endpoint, fullpath, value, disabled,
         pre_method, pre_args, post_method, post_args
     });
@@ -26,17 +26,27 @@ const EndpointSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
     const compMin = min ?? metadata?.min;
     const compMax = max ?? metadata?.max;
 
+    const component = useRef<HTMLInputElement>(null);
+
     const onChange: FormRangeProps["onChange"] = (event) => {
         const target = event.target;
         changeCompVal(Number(target.value))
     }
     const onMouseUp: FormRangeProps["onMouseUp"] = (event) => {
         const target = event.target as HTMLInputElement;
+        changeCompVal(Number(target.value));
         requestHandler(target.value);
     }
 
+    useEffect(() => {
+        const newVal = getValueFromPath<number>(endpoint.data, fullpath);
+        if(document.activeElement !== component.current && typeof newVal !== "undefined"){
+            changeCompVal(newVal);
+        }
+    }, [endpoint.updateFlag, data]);
+
     return (
-        <FormRange min={compMin} max={compMax} disabled={disable}
+        <FormRange ref={component} min={compMin} max={compMax} disabled={disable}
             onMouseUp={onMouseUp} onChange={onChange} value={compVal} {...rest}/>
     )
 }

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,17 +1,16 @@
 import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 
-import { getValueFromPath, isMetadataValue } from "../AdapterEndpoint";
+import { getValueFromPath } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
-import { useError } from "../OdinErrorContext";
 import { EndpointButton } from "./EndpointButton";
 import { EndpointCheckbox } from "./EndpointCheckbox";
 import { EndpointDropdown } from "./EndpointDropdown";
 import { EndpointInput } from "./EndpointInput";
+import { EndpointSlider } from "./EndpointSlider";
 import type { EndpointProps } from "./util";
 import { useRequestHandler } from "./util";
 // import { isEqual } from 'lodash';
 
-type value_t = "string" | "number" | "boolean" | "null" | "list" | "dict"
 
 
 type selectEvent_t = {
@@ -22,6 +21,25 @@ type selectEvent_t = {
 
 };
 
+/**
+ * A Generic Higher Order Compoennt that provides parameter read/write to the provided component
+ * This allows near any component that has some user interactivity (buttons, text boxes, etc)
+ * to automatically and directly control a parameter on an Adapter.
+ * 
+ * For the most part, the specific components already created should be used,
+ * as they cover the most commonly used options:
+ * {@link EndpointButton}
+ * {@link EndpointInput}
+ * {@link EndpointDropdown}
+ * {@link EndpointCheckbox}
+ * 
+ * @example
+ * //Created a Button that connects to a parameter
+ * const CustomEndpointButton = WithEndpoint(Button)
+ * @param WrappedComponent the component to add Endpoint access to
+ * @returns a new component with additional props, that automatically provides read/write access
+ * to a defined Parameter on the Adapter's Tree.
+ */
 const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
     /**
      * Combined Props for resulting WithEndpoint Component.
@@ -32,13 +50,12 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
 
     const WithEndpointComponent = <PreArgs extends unknown[], PostArgs extends unknown[]>(
         props: WrappedComponentProps<PreArgs, PostArgs>) => {
-        
+
         const { endpoint, fullpath, value, disabled,
             pre_method, pre_args, post_method, post_args,
             ...leftoverProps } = props;
 
         const component = useRef<Element>(null);
-        const ErrCTX = useError();
 
         const { requestHandler, data: endpointValue, disable } = useRequestHandler({
             endpoint, fullpath, value, disabled,
@@ -46,75 +63,12 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
             post_method, post_args
         })
 
-        const metadata: MetadataValue = getValueFromPath(endpoint.metadata, fullpath)
-            ?? {
-            value: endpointValue,
-            type: typeof endpointValue == "number" ? "int" : "str",
-            writeable: true
-        };
-        if ("min" in leftoverProps && leftoverProps.min !== undefined) {
-            metadata["min"] = leftoverProps["min"] as number;
-        }
-        if ("max" in leftoverProps && leftoverProps.max !== undefined) {
-            metadata["max"] = leftoverProps["max"] as number;
-        }
+        const metadata: MetadataValue | undefined = getValueFromPath(endpoint.metadata, fullpath);
 
 
         const [eventProp, setEventProp] = useState<selectEvent_t>({ onChange: (event) => onChangeHandler(event) });
         const [componentValue, setComponentValue] = useState<typeof value>(value ?? undefined);
         // const [metadata, setMetadata] = useState<metadata_t | null>(null);
-
-        const type: value_t = useMemo(() => {
-            if (isMetadataValue(metadata)) {
-                switch (metadata.type) {
-                    case "int":
-                    case "float":
-                    case "complex":
-                        return "number";
-                    case "list":
-                    case "tuple":
-                    case "range":
-                        return "list"
-                    case "bool":
-                        return "boolean"
-                    case "str":
-                        return "string"
-                    case "NoneType":
-                        return "null"
-                    default:
-                        return metadata.type as value_t;
-                }
-            } else {
-                const data_type = (value == null ? typeof endpointValue : typeof value);
-                switch (data_type) {
-                    case "bigint":
-                    case "number":
-                        return "number"
-                        break;
-                    case "object":
-                        // gotta check type of object
-                        switch (true) {
-                            case value ?? endpointValue instanceof Array:
-                                return "list"
-                            case value ?? endpointValue == null:
-                                return "null"
-                            default:
-                                return "dict"
-                        }
-                    case "function":
-                    case "symbol":
-                    case "undefined": {
-                        console.error("Something went wrong getting the typeof Data: ", value ?? endpointValue, data_type);
-                        const error = new Error(`Invalid Data type ${data_type} for path ${fullpath}. If Undefined, check fullPath is correct`);
-                        ErrCTX.setError(error);
-                        return "null";
-                    }
-                    case "boolean":
-                    case "string":
-                        return data_type;
-                }
-            }
-        }, [metadata]);
 
         const [editing, setEditing] = useState(false);
 
@@ -147,53 +101,6 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
             return { value: "", checked: false };
         }, [component.current, componentValue]);
 
-        const validate = (val: typeof value) => {
-            if (metadata) {
-                if (metadata.allowed_values && !(metadata.allowed_values.includes(val))) {
-                    throw Error(`Value ${val} not in allowed_values list: [${metadata.allowed_values.join(", ")}]`);
-                }
-                if (typeof val == "number") {
-                    if (metadata.min && metadata.min > val) {
-                        throw Error(`Value ${val} below minimum ${metadata.min}`);
-                    }
-                    if (metadata.max && metadata.max < val) {
-                        throw Error(`Value ${val} above maximum ${metadata.max}`);
-                    }
-                }
-            }
-        }
-
-        const getTypedValue = (val: typeof value): typeof endpointValue => {
-            switch (type) {
-                case "number":
-                    val = Number(val);
-                    break;
-                case "boolean":
-                    if (typeof val === "string" && val.toLowerCase() === "false") {
-                        val = false;
-                    } else { val = Boolean(val); }
-                    break;
-                case "list":
-                    if (Array.isArray(val)) {
-                        val = Array.from(val);
-                    } else {
-                        if (typeof val == "string") {
-                            val = val.split(",");
-                        }
-                    }
-                    break;
-                case "string":
-                    val = String(val);
-                    break;
-                case "dict":
-                case "null":
-                    break;
-
-            }
-
-            return val;
-        };
-
         useEffect(() => {
             // update flag got changed, check if we need to change anything
             if (value == null) {  // if value is defined, we dont wanna overwrite anything
@@ -207,19 +114,9 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
         }, [endpoint.updateFlag, endpointValue]);
 
         const handleRequest = (val: typeof value) => {
-            try {
-                val = getTypedValue(val);
-                validate(val);
-                requestHandler(val);
-                setEditing(false);
-            }
-            catch (err) {
-                if (err instanceof Error) {
-                    ErrCTX.setError(err);
-                } else {
-                    ErrCTX.setError(Error("UNKNOWN ERROR OCCURRED"));
-                }
-            }
+
+            requestHandler(val);
+            setEditing(false);
         };
 
         const onSelectHandler = (event: React.SyntheticEvent, eventKey: number | string) => {
@@ -319,10 +216,10 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
                 }
             }
             setEventProp(events);
-        }, [value, componentValue, component.current, type]);
+        }, [value, componentValue, component.current]);
 
         return (<WrappedComponent
-            {...leftoverProps as P}
+            {...Object.assign(leftoverProps, {min: metadata?.min, max: metadata?.max}) as P}
             style={style}
             {...eventProp}
             min={metadata?.min}
@@ -341,5 +238,7 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
 
 
 
-export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, WithEndpoint };
+export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, EndpointSlider };
+
+export {WithEndpoint};
 

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import React, { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 
 import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
@@ -6,12 +6,10 @@ import { isParamNode, getValueFromPath } from "../AdapterEndpoint";
 import { EndpointButton } from "./EndpointButton";
 import { EndpointInput } from "./EndpointInput";
 import { EndpointDropdown } from "./EndpointDropdown";
-import { sendRequest } from "./util";
+import { EndpointCheckbox } from "./EndpointCheckbox";
+import { useRequestHandler } from "./util";
 import { useError } from "../OdinErrorContext";
-import { isEqual } from 'lodash';
-
-// imported for defaults at the bottom
-import { Form } from "react-bootstrap";
+// import { isEqual } from 'lodash';
 
 type value_t = "string" | "number" | "boolean" | "null" | "list" | "dict"
 
@@ -73,37 +71,29 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
         const component = ref ?? useRef<Element>(null);
         const ErrCTX = useError();
 
+        const {requestHandler, data: endpointValue, disable} = useRequestHandler({
+            endpoint, fullpath, value, disabled,
+            pre_method, pre_args,
+            post_method, post_args
+        })
+
         //initialised with an OnChange handler to avoid the 
         // "You provided a `value` prop to a form field without an `onChange` handler" error, since
         // we will be assigning event handlers after component initialisation
         const [eventProp, setEventProp] = useState<selectEvent_t>({onChange: (event) => onChangeHandler(event)});
 
         const [componentValue, setComponentValue] = useState<typeof value>(value ?? undefined);
-        const [endpointValue, setEndpointValue] = useState<typeof value>(value ?? undefined);
+        // const [endpointValue, setEndpointValue] = useState<typeof value>(value ?? undefined);
         const [metadata, setMetadata] = useState<metadata_t | null>(null);
 
         const [type, setType] = useState<value_t>("string");
 
-        const [isPending, startTransition] = useTransition();
+        const [editing, setEditing] = useState(false);
 
         const changedStyle: CSSProperties = {
-            backgroundColor: dif_color,
-            color: "var(--bs-body-color)"
+            backgroundColor: dif_color
         }
-        const style: CSSProperties = ["null", "list", "dict"].includes(type) ? 
-                isEqual(endpointValue, componentValue) ? {} : changedStyle :
-                componentValue == endpointValue ? {} : changedStyle;
-
-        const disable = useMemo(() => {
-            if(disabled !== undefined){
-                return (disabled || isPending || endpoint.loading)
-            }
-            if(metadata){
-                return isPending || endpoint.loading || metadata.readOnly
-            }
-            return isPending || endpoint.loading;
-
-        }, [isPending, endpoint.loading, disabled, metadata?.readOnly]);
+        const style: CSSProperties = editing ? changedStyle : {};
 
         const componentPassedValue = useMemo(() => {
             const curComponent = component.current;
@@ -258,7 +248,6 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                             setType(data_type);
                     }
                 }
-                setEndpointValue(val);
                 setComponentValue(val);
                 setMetadata(tmp_metadata);
             }
@@ -268,13 +257,9 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             // update flag got changed, check if we need to change anything
             if(value == null){  // if value is defined, we dont wanna overwrite anything
                 const newVal = getValueFromPath<ComponentProps['value']>(endpoint.data, fullpath);
-                if(newVal != endpointValue){
-                    setEndpointValue(newVal);
-                }
                 // check if component value has been modified, or if the input is active. If so,
-                // dont mess with the value. Otherwise, set the component val?
-                // seems weird to be checking if the two values are the same specifically to change them
-                if(document.activeElement !== component.current && value == null && endpointValue == componentValue){
+                // dont mess with the value. Otherwise, set the component val
+                if(document.activeElement !== component.current && !editing && typeof newVal !== "undefined"){
                     setComponentValue(newVal);
                 }
             }
@@ -284,16 +269,8 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             try {
                 val = getTypedValue(val);
                 validate(val);
-
-                startTransition(async () => {
-                    pre_method?.(...(pre_args ?? []));
-
-                    
-                    sendRequest(val, endpoint, fullpath)
-                    .then(() => {
-                        post_method?.(...(post_args ?? []));
-                    });
-                })
+                requestHandler(val);
+                setEditing(false);
             }
             catch (err) {
                 if(err instanceof Error){
@@ -342,6 +319,7 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                 val = component.current.value as ComponentProps['value'];
             }
             setComponentValue(val);
+            setEditing(!(val == endpointValue));
 
             // special case. If the underlying component is a html <select> tag, send the request
             // without needing the onEnterHandler
@@ -421,8 +399,6 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
     )
 };
 
-// const EndpointDropdown = WithEndpoint(DropdownButton);
-const EndpointCheckbox = WithEndpoint(Form.Check);
 
 
 export {EndpointInput, EndpointButton, EndpointDropdown, EndpointCheckbox};

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -4,6 +4,8 @@ import type { AdapterEndpoint, ParamNode, ParamTree } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { isParamNode, getValueFromPath } from "../AdapterEndpoint";
 import { EndpointButton } from "./EndpointButton";
+import { EndpointInput } from "./EndpointInput";
+import { sendRequest } from "./util";
 import { useError } from "../OdinErrorContext";
 import { isEqual } from 'lodash';
 
@@ -104,16 +106,6 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             return isPending || endpoint.loading;
 
         }, [isPending, endpoint.loading, disabled, metadata?.readOnly]);
-
-        const {path, valueName} = useMemo(() => {
-            let path = "";
-            let valueName = trimByChar(fullpath, "/");
-            if(valueName.includes("/"))
-            {
-                [path, valueName] = valueName.split(/\/(?!.*\/)(.*)/, 2); // finds the last "/" in the string, and splits on that
-            }
-            return {path, valueName};
-        }, [fullpath]);
 
         const componentPassedValue = useMemo(() => {
             const curComponent = component.current;
@@ -290,39 +282,19 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             }
         }, [endpoint.updateFlag, endpointValue]);
 
-        const sendRequest = (val: ComponentProps['value']) => {
+        const handleRequest = (val: ComponentProps['value']) => {
             try {
                 val = getTypedValue(val);
                 validate(val);
 
                 startTransition(async () => {
+                    pre_method?.(...(pre_args ?? []));
 
-                    if(pre_method)
-                    {
-                        if(pre_args)
-                        {
-                            pre_method(...pre_args);
-                        }else{
-                            pre_method();
-                        }
-                    }
-                    const sendVal = {[valueName]: val};
-
-                    endpoint.put(sendVal, path)
-                        .then((response) => {
-                            endpoint.mergeData(response, path);
-                            if(post_method)
-                            {
-                                if(post_args){
-                                    post_method(...post_args);
-                                }else{
-                                    post_method();
-                                }
-                            }
-                        })
-                        .catch((error) => {
-                            console.debug("Error in PUT occured in WithEndpoint component", error);
-                        });
+                    
+                    sendRequest(val, endpoint, fullpath)
+                    .then(() => {
+                        post_method?.(...(post_args ?? []));
+                    });
                 })
             }
             catch (err) {
@@ -339,7 +311,7 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             console.debug(fullpath, "event: ", event);
             console.debug(fullpath, "EventKey: ", eventKey);
             
-            sendRequest(eventKey);
+            handleRequest(eventKey);
         }
 
         const onClickHandler = (event: React.MouseEvent) => {
@@ -357,7 +329,7 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                     val = "value" in curComponent ? curComponent.value as ComponentProps['value'] : value;
                 }
             }
-            sendRequest(val);
+            handleRequest(val);
         };
 
         const onChangeHandler = (event: React.ChangeEvent) => {
@@ -377,13 +349,13 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             // without needing the onEnterHandler
             const compType = component.current?.nodeName;
             if(compType === "SELECT"){
-                sendRequest(val);
+                handleRequest(val);
             }
         };
 
         const onEnterHandler = (event: React.KeyboardEvent) => {
             if (event.key === "Enter" && !event.shiftKey) {
-                sendRequest(componentValue);
+                handleRequest(componentValue);
             }
         };
 
@@ -465,8 +437,6 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
     )
 };
 
-const EndpointInput = WithEndpoint(Form.Control);
-// const EndpointButton = WithEndpoint(Button);
 const EndpointDropdown = WithEndpoint(DropdownButton);
 const EndpointCheckbox = WithEndpoint(Form.Check);
 

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -4,6 +4,7 @@ import { getValueFromPath } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { EndpointButton } from "./EndpointButton";
 import { EndpointCheckbox } from "./EndpointCheckbox";
+import { EndpointDoubleSlider } from "./EndpointDoubleSlider";
 import { EndpointDropdown } from "./EndpointDropdown";
 import { EndpointInput } from "./EndpointInput";
 import { EndpointSlider } from "./EndpointSlider";
@@ -219,7 +220,7 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
         }, [value, componentValue, component.current]);
 
         return (<WrappedComponent
-            {...Object.assign(leftoverProps, {min: metadata?.min, max: metadata?.max}) as P}
+            {...Object.assign(leftoverProps, { min: metadata?.min, max: metadata?.max }) as P}
             style={style}
             {...eventProp}
             min={metadata?.min}
@@ -238,7 +239,14 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
 
 
 
-export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, EndpointSlider };
+export {
+    EndpointButton,
+    EndpointCheckbox,
+    EndpointDoubleSlider,
+    EndpointDropdown,
+    EndpointInput,
+    EndpointSlider
+};
 
-export {WithEndpoint};
+export { WithEndpoint };
 

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,155 +1,183 @@
-import React, { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
+import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 
-import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
+import { getValueFromPath, isParamNode } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
-import { isParamNode, getValueFromPath } from "../AdapterEndpoint";
-import { EndpointButton } from "./EndpointButton";
-import { EndpointInput } from "./EndpointInput";
-import { EndpointDropdown } from "./EndpointDropdown";
-import { EndpointCheckbox } from "./EndpointCheckbox";
-import { useRequestHandler } from "./util";
 import { useError } from "../OdinErrorContext";
+import { EndpointButton } from "./EndpointButton";
+import { EndpointCheckbox } from "./EndpointCheckbox";
+import { EndpointDropdown } from "./EndpointDropdown";
+import { EndpointInput } from "./EndpointInput";
+import type { EndpointProps } from "./util";
+import { useRequestHandler } from "./util";
 // import { isEqual } from 'lodash';
 
 type value_t = "string" | "number" | "boolean" | "null" | "list" | "dict"
 
-interface ComponentProps {
-    endpoint: AdapterEndpoint;
-    fullpath: string;
-    value?: ParamTree;
-    min?: number;
-    max?: number;
-    disabled?: boolean;
-    pre_method?: (...args: unknown[]) => void;
-    post_method?: (...args: unknown[]) => void;
-    pre_args?:Array<unknown>;
-    post_args?:Array<unknown>;
-    dif_color?: CSSProperties["backgroundColor"];
-    ref?: React.RefObject<Element>;
-}
 
-interface metadata_t {
-    readOnly: MetadataValue["writeable"];
-    min?: number;
-    max?: number;
-    allowed_values?: MetadataValue["allowed_values"];
-    type?: string;
-}
-
-type selectEvent_t = {onSelect?: (eventKey: number | string, event: React.SyntheticEvent) => void,
-                      onClick?: (event: React.MouseEvent) => void,
-                      onKeyPress?: (event: React.KeyboardEvent) => void,
-                      onChange?: (event: React.ChangeEvent) => void
+type selectEvent_t = {
+    onSelect?: (eventKey: number | string, event: React.SyntheticEvent) => void,
+    onClick?: (event: React.MouseEvent) => void,
+    onKeyPress?: (event: React.KeyboardEvent) => void,
+    onChange?: (event: React.ChangeEvent) => void
 
 };
 
-type InjectedProps = metadata_t & selectEvent_t & {
-    style?: React.CSSProperties,
-    value?: JSON,
-    disabled: boolean
-
-}
-
-const trimByChar = (string: string, character: string) => {
-        const arr = Array.from(string);
-        const first = arr.findIndex(char => char !==character);
-        const last = arr.reverse().findIndex(char => char !== character);
-        return (first === -1 && last === -1) ? '' : string.substring(first, string.length - last);
-    }
-
-const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) => 
-{
-    type WrapperComponentProps = React.PropsWithChildren<
-             Omit<P, keyof InjectedProps> & ComponentProps>;
+const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
+    /**
+     * Combined Props for resulting WithEndpoint Component.
+     * Combines {@link EndpointProps} with the props of whatever component is being wrapped.*/
+    type WrappedComponentProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+        EndpointProps<PreArgs, PostArgs> & P;
 
 
-    const WithEndpointComponent: React.FC<WrapperComponentProps> = (props) => {
-        const {endpoint, fullpath, value, disabled,
-               pre_method, pre_args, post_method, post_args, dif_color="var(--bs-highlight-bg)",
-               min, max, ref, ...leftoverProps} = props;
+    const WithEndpointComponent = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+        props: WrappedComponentProps<PreArgs, PostArgs>) => {
+        
+        const { endpoint, fullpath, value, disabled,
+            pre_method, pre_args, post_method, post_args,
+            ...leftoverProps } = props;
 
-        const component = ref ?? useRef<Element>(null);
+        const component = useRef<Element>(null);
         const ErrCTX = useError();
 
-        const {requestHandler, data: endpointValue, disable} = useRequestHandler({
+        const { requestHandler, data: endpointValue, disable } = useRequestHandler({
             endpoint, fullpath, value, disabled,
             pre_method, pre_args,
             post_method, post_args
         })
 
-        //initialised with an OnChange handler to avoid the 
-        // "You provided a `value` prop to a form field without an `onChange` handler" error, since
-        // we will be assigning event handlers after component initialisation
-        const [eventProp, setEventProp] = useState<selectEvent_t>({onChange: (event) => onChangeHandler(event)});
+        const metadata: MetadataValue = getValueFromPath(endpoint.metadata, fullpath)
+            ?? {
+            value: endpointValue,
+            type: typeof endpointValue == "number" ? "int" : "str",
+            writeable: true
+        };
+        if ("min" in leftoverProps && leftoverProps.min !== undefined) {
+            metadata["min"] = leftoverProps["min"] as number;
+        }
+        if ("max" in leftoverProps && leftoverProps.max !== undefined) {
+            metadata["max"] = leftoverProps["max"] as number;
+        }
 
+
+        const [eventProp, setEventProp] = useState<selectEvent_t>({ onChange: (event) => onChangeHandler(event) });
         const [componentValue, setComponentValue] = useState<typeof value>(value ?? undefined);
-        // const [endpointValue, setEndpointValue] = useState<typeof value>(value ?? undefined);
-        const [metadata, setMetadata] = useState<metadata_t | null>(null);
+        // const [metadata, setMetadata] = useState<metadata_t | null>(null);
 
-        const [type, setType] = useState<value_t>("string");
+        const type: value_t = useMemo(() => {
+            if (isParamNode(metadata) && "writeable" in metadata) {
+                switch (metadata.type) {
+                    case "int":
+                    case "float":
+                    case "complex":
+                        return "number";
+                    case "list":
+                    case "tuple":
+                    case "range":
+                        return "list"
+                    case "bool":
+                        return "boolean"
+                    case "str":
+                        return "string"
+                    case "NoneType":
+                        return "null"
+                    default:
+                        return metadata.type as value_t;
+                }
+            } else {
+                const data_type = (value == null ? typeof endpointValue : typeof value);
+                switch (data_type) {
+                    case "bigint":
+                    case "number":
+                        return "number"
+                        break;
+                    case "object":
+                        // gotta check type of object
+                        switch (true) {
+                            case value ?? endpointValue instanceof Array:
+                                return "list"
+                            case value ?? endpointValue == null:
+                                return "null"
+                            default:
+                                return "dict"
+                        }
+                    case "function":
+                    case "symbol":
+                    case "undefined": {
+                        console.error("Something went wrong getting the typeof Data: ", value ?? endpointValue, data_type);
+                        const error = new Error(`Invalid Data type ${data_type} for path ${fullpath}. If Undefined, check fullPath is correct`);
+                        ErrCTX.setError(error);
+                        return "null";
+                    }
+                    case "boolean":
+                    case "string":
+                        return data_type;
+                }
+            }
+        }, [metadata]);
 
         const [editing, setEditing] = useState(false);
 
         const changedStyle: CSSProperties = {
-            backgroundColor: dif_color
+            backgroundColor: "var(--bs-highlight-bg)"
         }
         const style: CSSProperties = editing ? changedStyle : {};
 
         const componentPassedValue = useMemo(() => {
             const curComponent = component.current;
             const val = componentValue ?? "";
-            if(curComponent){
+            if (curComponent) {
                 // coded using switch case to future proof if there's other special case component types
-                switch(curComponent.nodeName){
+                switch (curComponent.nodeName) {
                     case "INPUT":
                         {
                             const input_type = (curComponent as HTMLInputElement).type;
-                            switch(input_type){
+                            switch (input_type) {
                                 case "checkbox":
                                 case "radio":
-                                    return {checked: Boolean(val)};
+                                    return { checked: Boolean(val) };
                                 default:
-                                    return {value: val};
+                                    return { value: val };
                             }
                         }
                     default:
-                        return {value: val};
+                        return { value: val };
                 }
             }
-            return {value: "", checked: false};
+            return { value: "", checked: false };
         }, [component.current, componentValue]);
 
-        const validate = (value: ComponentProps['value']) => {
-            if(metadata){
-                if(metadata.allowed_values && !(metadata.allowed_values.includes(value))){
-                    throw Error(`Value ${value} not in allowed_values list: [${metadata.allowed_values.join(", ")}]`);
+        const validate = (val: typeof value) => {
+            if (metadata) {
+                if (metadata.allowed_values && !(metadata.allowed_values.includes(val))) {
+                    throw Error(`Value ${val} not in allowed_values list: [${metadata.allowed_values.join(", ")}]`);
                 }
-                if(typeof value == "number"){
-                    if(metadata.min && metadata.min > value){
-                        throw Error(`Value ${value} below minimum ${metadata.min}`);
+                if (typeof val == "number") {
+                    if (metadata.min && metadata.min > val) {
+                        throw Error(`Value ${val} below minimum ${metadata.min}`);
                     }
-                    if(metadata.max && metadata.max < value){
-                        throw Error(`Value ${value} above maximum ${metadata.max}`);
+                    if (metadata.max && metadata.max < val) {
+                        throw Error(`Value ${val} above maximum ${metadata.max}`);
                     }
                 }
             }
         }
 
-        const getTypedValue = (val: ComponentProps['value']): ComponentProps['value'] => {
-            switch(type){
+        const getTypedValue = (val: typeof value): typeof endpointValue => {
+            switch (type) {
                 case "number":
-                    val =  Number(val);
+                    val = Number(val);
                     break;
                 case "boolean":
-                    if(typeof val === "string" && val.toLowerCase() === "false"){
+                    if (typeof val === "string" && val.toLowerCase() === "false") {
                         val = false;
-                    }else{val = Boolean(val);}
+                    } else { val = Boolean(val); }
                     break;
                 case "list":
-                    if(Array.isArray(val)){
+                    if (Array.isArray(val)) {
                         val = Array.from(val);
-                    }else{
-                        if(typeof val == "string"){
+                    } else {
+                        if (typeof val == "string") {
                             val = val.split(",");
                         }
                     }
@@ -167,105 +195,18 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
         };
 
         useEffect(() => {
-            //this effect is designed to run only when the component is first mounted, to get the data
-            //and metadata of the part of the param tree we are interacting with, apply the metadata
-            //validation to the component (writable, min, max) and sync the component value with the
-            //value from the param tree
-            const endpointLoaded = () => {
-                for(const _ in endpoint.metadata) return true;
-                return false;
-            }
-            if(endpointLoaded() && endpoint.status != "error"){
-                const metadata = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath);
-                let val: ParamTree;
-                const tmp_metadata: metadata_t = {readOnly: false, min: min, max: max};
-                if(isParamNode(metadata) && "writeable" in metadata){ //metadata found
-                    tmp_metadata.readOnly = !(metadata.writeable);
-                    tmp_metadata.min = min ?? (metadata.min ? metadata.min : undefined);
-                    tmp_metadata.max = max ?? (metadata.max ? metadata.max : undefined);
-                    tmp_metadata.allowed_values = metadata?.allowed_values;
-
-                    // setMetadata(tmp_metadata);
-                    val = value ?? metadata.value;
-
-                    switch(metadata.type as string){
-                        case "int":
-                        case "float":
-                        case "complex":
-                            setType("number");
-                            break;
-                        case "list":
-                        case "tuple":
-                        case "range":
-                            setType("list");
-                            break;
-                        case "bool":
-                            setType("boolean");
-                            break;
-                        case "str":
-                            setType("string");
-                            break;
-                        case "NoneType":
-                            setType("null");
-                            break;
-                        default:
-                            setType(metadata.type as value_t);
-                    }
-
-                }else{
-                    const data = getValueFromPath<ComponentProps['value']>(endpoint.data, fullpath);
-                    console.debug("Adapter has not implemented Metadata for", fullpath);
-                    val = value ?? data as ComponentProps["value"];
-                    const data_type = (value == null ? typeof data : typeof value);
-                    switch(data_type){
-                        case "bigint":
-                        case "number":
-                            setType("number");
-                            break;
-                        case "object":
-                            // gotta check type of object
-                            switch(true){
-                                case data instanceof Array:
-                                    setType("list");
-                                    break;
-                                case data == null:
-                                    setType("null");
-                                    break;
-                                default:
-                                    setType("dict");
-                            }
-                            break;
-                        case "function":
-                        case "symbol":
-                        case "undefined": {
-                            console.error("Something went wrong getting the typeof Data: ", data, typeof data);
-                            const error = new Error(`Invalid Data type ${data_type} for path ${fullpath}. If Undefined, check fullPath is correct`);
-                            ErrCTX.setError(error);
-                            break;
-                        }
-                        case "boolean":
-                        case "string":
-                            setType(data_type);
-                    }
-                }
-                setComponentValue(val);
-                setMetadata(tmp_metadata);
-            }
-        }, [endpoint.metadata]);
-
-        useEffect(() => {
             // update flag got changed, check if we need to change anything
-            if(value == null){  // if value is defined, we dont wanna overwrite anything
-                const newVal = getValueFromPath<ComponentProps['value']>(endpoint.data, fullpath);
+            if (value == null) {  // if value is defined, we dont wanna overwrite anything
+                const newVal = getValueFromPath<typeof value>(endpoint.data, fullpath);
                 // check if component value has been modified, or if the input is active. If so,
                 // dont mess with the value. Otherwise, set the component val
-                if(document.activeElement !== component.current && !editing && typeof newVal !== "undefined"){
+                if (document.activeElement !== component.current && !editing && typeof newVal !== "undefined") {
                     setComponentValue(newVal);
                 }
             }
         }, [endpoint.updateFlag, endpointValue]);
 
-        const handleRequest = (val: ComponentProps['value']) => {
+        const handleRequest = (val: typeof value) => {
             try {
                 val = getTypedValue(val);
                 validate(val);
@@ -273,9 +214,9 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
                 setEditing(false);
             }
             catch (err) {
-                if(err instanceof Error){
+                if (err instanceof Error) {
                     ErrCTX.setError(err);
-                }else{
+                } else {
                     ErrCTX.setError(Error("UNKNOWN ERROR OCCURRED"));
                 }
             }
@@ -285,23 +226,23 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
             console.debug(fullpath, "On Select Handler");
             console.debug(fullpath, "event: ", event);
             console.debug(fullpath, "EventKey: ", eventKey);
-            
+
             handleRequest(eventKey);
         }
 
         const onClickHandler = (event: React.MouseEvent) => {
             console.debug(fullpath, event);
             const curComponent = component.current!;
-            let val: ComponentProps['value'];
-            if(value != null){
+            let val: typeof value;
+            if (value != null) {
                 val = value;
-            }else{
+            } else {
                 const compType = component.current!.nodeName;
                 // if the type of component is a checkbox or a radio button, get the value from the "checked" prop
-                if(compType === "INPUT" && ["checkbox", "radio"].includes((component.current! as HTMLInputElement).type)){
-                        val = (component.current! as HTMLInputElement).checked;
-                }else{
-                    val = "value" in curComponent ? curComponent.value as ComponentProps['value'] : value;
+                if (compType === "INPUT" && ["checkbox", "radio"].includes((component.current! as HTMLInputElement).type)) {
+                    val = (component.current! as HTMLInputElement).checked;
+                } else {
+                    val = "value" in curComponent ? curComponent.value as typeof value : value;
                 }
             }
             handleRequest(val);
@@ -310,21 +251,21 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
         const onChangeHandler = (event: React.ChangeEvent) => {
             //this onChange handler sets the ComponentValue State, to manage the component and monitor its value
             const target = event.target;
-            let val: ComponentProps['value'] = "";
-        
-            if("value" in target && target.value != null){
-                val = target.value as ComponentProps['value'];
-            }else
-            if("value" in component.current!){
-                val = component.current.value as ComponentProps['value'];
-            }
+            let val: typeof value = "";
+
+            if ("value" in target && target.value != null) {
+                val = target.value as typeof value;
+            } else
+                if ("value" in component.current!) {
+                    val = component.current.value as typeof value;
+                }
             setComponentValue(val);
             setEditing(!(val == endpointValue));
 
             // special case. If the underlying component is a html <select> tag, send the request
             // without needing the onEnterHandler
             const compType = component.current?.nodeName;
-            if(compType === "SELECT"){
+            if (compType === "SELECT") {
                 handleRequest(val);
             }
         };
@@ -336,44 +277,44 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
         };
 
         useEffect(() => {
-            let events: selectEvent_t = {onKeyPress: (event) => onEnterHandler(event), onChange: (event) => onChangeHandler(event)};
-                const curComponent = component.current;
-            if(curComponent){
-                switch(curComponent.nodeName){
+            let events: selectEvent_t = { onKeyPress: (event) => onEnterHandler(event), onChange: (event) => onChangeHandler(event) };
+            const curComponent = component.current;
+            if (curComponent) {
+                switch (curComponent.nodeName) {
                     case "BUTTON":
                         //default buttons to using the onClick event handler
-                        events = {onClick: (event) => onClickHandler(event)};
+                        events = { onClick: (event) => onClickHandler(event) };
                         break;
 
-                    case "INPUT": 
-                    {
-                        const input_type = (curComponent as HTMLInputElement).type;
-                        switch(input_type){
-                            case "checkbox":
-                            case "radio":
-                                //default checkboxes and radios to using the onClick event handler
-                                events = {onClick: (event) => onClickHandler(event)};
-                                break;
-                            case "text":
-                            case "number":
-                            default:
-                                break;
+                    case "INPUT":
+                        {
+                            const input_type = (curComponent as HTMLInputElement).type;
+                            switch (input_type) {
+                                case "checkbox":
+                                case "radio":
+                                    //default checkboxes and radios to using the onClick event handler
+                                    events = { onClick: (event) => onClickHandler(event) };
+                                    break;
+                                case "text":
+                                case "number":
+                                default:
+                                    break;
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case "DIV":
-                    {
-                        const divClass = (curComponent as HTMLDivElement).className;
-                        if(divClass === "dropdown"){
-                            //bootstrap dropdowns are contained in a div with a classname of "dropdown"
-                            events = {onSelect: (eventKey, event) => onSelectHandler(event, eventKey)};
+                        {
+                            const divClass = (curComponent as HTMLDivElement).className;
+                            if (divClass === "dropdown") {
+                                //bootstrap dropdowns are contained in a div with a classname of "dropdown"
+                                events = { onSelect: (eventKey, event) => onSelectHandler(event, eventKey) };
+                            }
+                            break;
                         }
-                        break;
-                    }
                     case "SELECT":
                         // the onSelect event handler is a specially created one for bootstrap dropdowns
                         // standard html dropdowns (<select> tags) use the onChange event handler by default
-                        events = {onChange: (event) => onChangeHandler(event)};
+                        events = { onChange: (event) => onChangeHandler(event) };
                         break;
                 }
             }
@@ -381,16 +322,15 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
         }, [value, componentValue, component.current, type]);
 
         return (<WrappedComponent
-                    {...leftoverProps as P}
-                    style={style}
-                    {...eventProp}
-                    readOnly={metadata?.readOnly}
-                    min={metadata?.min}
-                    max={metadata?.max}
-                    {...componentPassedValue}
-                    disabled={disable}
-                    ref={component}
-                />)
+            {...leftoverProps as P}
+            style={style}
+            {...eventProp}
+            min={metadata?.min}
+            max={metadata?.max}
+            {...componentPassedValue}
+            disabled={disable}
+            ref={component}
+        />)
 
     }
 
@@ -401,8 +341,5 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
 
 
 
-export {EndpointInput, EndpointButton, EndpointDropdown, EndpointCheckbox};
-
-
-export { WithEndpoint, trimByChar };
+export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, WithEndpoint };
 

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,28 +1,26 @@
 import React, { CSSProperties, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
-import type { AdapterEndpoint, ParamNode, ParamTree } from "../AdapterEndpoint";
+import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { isParamNode, getValueFromPath } from "../AdapterEndpoint";
 import { EndpointButton } from "./EndpointButton";
 import { EndpointInput } from "./EndpointInput";
+import { EndpointDropdown } from "./EndpointDropdown";
 import { sendRequest } from "./util";
 import { useError } from "../OdinErrorContext";
 import { isEqual } from 'lodash';
 
 // imported for defaults at the bottom
-import { Form, DropdownButton } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 
-type event_t = "select" | "click" | "enter"
 type value_t = "string" | "number" | "boolean" | "null" | "list" | "dict"
 
 interface ComponentProps {
     endpoint: AdapterEndpoint;
     fullpath: string;
-    value?: ParamNode[keyof ParamNode];
-    // value_type?: value_t;
+    value?: ParamTree;
     min?: number;
     max?: number;
-    event_type?: event_t;
     disabled?: boolean;
     pre_method?: (...args: unknown[]) => void;
     post_method?: (...args: unknown[]) => void;
@@ -68,7 +66,7 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
 
 
     const WithEndpointComponent: React.FC<WrapperComponentProps> = (props) => {
-        const {endpoint, fullpath, value, event_type, disabled,
+        const {endpoint, fullpath, value, disabled,
                pre_method, pre_args, post_method, post_args, dif_color="var(--bs-highlight-bg)",
                min, max, ref, ...leftoverProps} = props;
 
@@ -361,62 +359,48 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
 
         useEffect(() => {
             let events: selectEvent_t = {onKeyPress: (event) => onEnterHandler(event), onChange: (event) => onChangeHandler(event)};
-            if(event_type){
-                switch(event_type){
-                    case "select":
-                        events = {onSelect: (eventKey, event) => onSelectHandler(event, eventKey)};
-                        break;
-                    case "click":
+                const curComponent = component.current;
+            if(curComponent){
+                switch(curComponent.nodeName){
+                    case "BUTTON":
+                        //default buttons to using the onClick event handler
                         events = {onClick: (event) => onClickHandler(event)};
                         break;
-                    case "enter":
-                    default:
-                        break;
-                }
-            }else{
-                const curComponent = component.current;
-                if(curComponent){
-                    switch(curComponent.nodeName){
-                        case "BUTTON":
-                            //default buttons to using the onClick event handler
-                            events = {onClick: (event) => onClickHandler(event)};
-                            break;
 
-                        case "INPUT": 
-                        {
-                            const input_type = (curComponent as HTMLInputElement).type;
-                            switch(input_type){
-                                case "checkbox":
-                                case "radio":
-                                    //default checkboxes and radios to using the onClick event handler
-                                    events = {onClick: (event) => onClickHandler(event)};
-                                    break;
-                                case "text":
-                                case "number":
-                                default:
-                                    break;
-                            }
-                            break;
+                    case "INPUT": 
+                    {
+                        const input_type = (curComponent as HTMLInputElement).type;
+                        switch(input_type){
+                            case "checkbox":
+                            case "radio":
+                                //default checkboxes and radios to using the onClick event handler
+                                events = {onClick: (event) => onClickHandler(event)};
+                                break;
+                            case "text":
+                            case "number":
+                            default:
+                                break;
                         }
-                        case "DIV":
-                        {
-                            const divClass = (curComponent as HTMLDivElement).className;
-                            if(divClass === "dropdown"){
-                                //bootstrap dropdowns are contained in a div with a classname of "dropdown"
-                                events = {onSelect: (eventKey, event) => onSelectHandler(event, eventKey)};
-                            }
-                            break;
-                        }
-                        case "SELECT":
-                            // the onSelect event handler is a specially created one for bootstrap dropdowns
-                            // standard html dropdowns (<select> tags) use the onChange event handler by default
-                           events = {onChange: (event) => onChangeHandler(event)};
-                            break;
+                        break;
                     }
+                    case "DIV":
+                    {
+                        const divClass = (curComponent as HTMLDivElement).className;
+                        if(divClass === "dropdown"){
+                            //bootstrap dropdowns are contained in a div with a classname of "dropdown"
+                            events = {onSelect: (eventKey, event) => onSelectHandler(event, eventKey)};
+                        }
+                        break;
+                    }
+                    case "SELECT":
+                        // the onSelect event handler is a specially created one for bootstrap dropdowns
+                        // standard html dropdowns (<select> tags) use the onChange event handler by default
+                        events = {onChange: (event) => onChangeHandler(event)};
+                        break;
                 }
             }
             setEventProp(events);
-        }, [event_type, value, componentValue, component.current, type]);
+        }, [value, componentValue, component.current, type]);
 
         return (<WrappedComponent
                     {...leftoverProps as P}
@@ -437,7 +421,7 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
     )
 };
 
-const EndpointDropdown = WithEndpoint(DropdownButton);
+// const EndpointDropdown = WithEndpoint(DropdownButton);
 const EndpointCheckbox = WithEndpoint(Form.Check);
 
 

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 
-import { getValueFromPath, isParamNode } from "../AdapterEndpoint";
+import { getValueFromPath, isMetadataValue } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { useError } from "../OdinErrorContext";
 import { EndpointButton } from "./EndpointButton";
@@ -65,7 +65,7 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
         // const [metadata, setMetadata] = useState<metadata_t | null>(null);
 
         const type: value_t = useMemo(() => {
-            if (isParamNode(metadata) && "writeable" in metadata) {
+            if (isMetadataValue(metadata)) {
                 switch (metadata.type) {
                     case "int":
                     case "float":

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -3,11 +3,12 @@ import React, { CSSProperties, useEffect, useMemo, useRef, useState, useTransiti
 import type { AdapterEndpoint, ParamNode, ParamTree } from "../AdapterEndpoint";
 import type { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { isParamNode, getValueFromPath } from "../AdapterEndpoint";
+import { EndpointButton } from "./EndpointButton";
 import { useError } from "../OdinErrorContext";
 import { isEqual } from 'lodash';
 
 // imported for defaults at the bottom
-import { Form, Button, DropdownButton } from "react-bootstrap";
+import { Form, DropdownButton } from "react-bootstrap";
 
 type event_t = "select" | "click" | "enter"
 type value_t = "string" | "number" | "boolean" | "null" | "list" | "dict"
@@ -464,9 +465,8 @@ const WithEndpoint = <P extends object>(WrappedComponent : React.FC<P>) =>
     )
 };
 
-
 const EndpointInput = WithEndpoint(Form.Control);
-const EndpointButton = WithEndpoint(Button);
+// const EndpointButton = WithEndpoint(Button);
 const EndpointDropdown = WithEndpoint(DropdownButton);
 const EndpointCheckbox = WithEndpoint(Form.Check);
 

--- a/lib/components/WithEndpoint/util.ts
+++ b/lib/components/WithEndpoint/util.ts
@@ -1,18 +1,25 @@
+import { useTransition } from "react";
 import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
-import { isParamNode } from "../AdapterEndpoint";
+import { getValueFromPath, isParamNode } from "../AdapterEndpoint";
+import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 
 
 export interface EndpointProps<PreArgs extends unknown[], PostArgs extends unknown[]> {
     endpoint: AdapterEndpoint;
     fullpath: string;
     value?: ParamTree;
-    min?: number;
-    max?: number;
     disabled?: boolean;
     pre_method?: (...args: PreArgs) => void;
     post_method?: (...args: PostArgs) => void;
     pre_args?: PreArgs;
     post_args?: PostArgs;
+}
+
+interface RequestHandler {
+    requestHandler: (val?: ParamTree) => void;
+    data: ParamTree;
+    disable: boolean;
+
 }
 
 const getLastPathPart = (path: string): [string, string] => {
@@ -51,5 +58,37 @@ export async function sendRequest<T extends ParamTree>(val: T, endpoint: Adapter
     }catch (err){
         console.debug("Error in PUT occured in WithEndpoint component", err);
     }
+}
+
+export function useRequestHandler<PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled,
+        pre_method, pre_args,
+        post_method, post_args } : EndpointProps<PreArgs, PostArgs>
+): RequestHandler {
+
+    const [isPending, startTransition] = useTransition();
+
+    const data: ParamTree = value ?? getValueFromPath(endpoint.data, fullpath);
+    const metadata: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
+                                        ?? {value: data,
+                                            type: typeof data == "number" ? "int" : "str",
+                                            writeable: true};
+
+    const disable = disabled || isPending || endpoint.loading || !(metadata.writeable);
+
+    const requestHandler: RequestHandler["requestHandler"] = (val) => {
+        startTransition(async () => {
+
+            pre_method?.(...(pre_args ?? []) as PreArgs);
+
+            sendRequest(val ?? data, endpoint, fullpath)
+            .then(() => {
+                post_method?.(...(post_args ?? []) as PostArgs);
+            });
+        })
+    }
+
+    return {requestHandler, data, disable}
+
 }
 

--- a/lib/components/WithEndpoint/util.ts
+++ b/lib/components/WithEndpoint/util.ts
@@ -1,7 +1,8 @@
-import { useTransition } from "react";
+import { useMemo, useTransition } from "react";
 import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
-import { getValueFromPath, isParamNode } from "../AdapterEndpoint";
+import { getValueFromPath, isMetadataValue, isParamNode } from "../AdapterEndpoint";
 import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
+import { useError } from "../OdinErrorContext";
 
 
 export interface EndpointProps<PreArgs extends unknown[], PostArgs extends unknown[]> {
@@ -22,6 +23,8 @@ interface RequestHandler {
 
 }
 
+type dataTypes = "string" | "number" | "boolean" | "null" | "list" | "dict"
+
 const getLastPathPart = (path: string): [string, string] => {
     const splitPath = path.replace(/\/$/, "").split("/");
     const name = splitPath.pop() ?? "";
@@ -38,57 +41,151 @@ const getLastPathPart = (path: string): [string, string] => {
  * @param endpoint AdapterEndpoint to handle the PUT request
  * @param path Path to the parameter
  */
-export async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoint, path: string): Promise<void> {
+async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoint, path: string): Promise<void> {
 
-    const [sendVal, sendPath] = (function() {
-        if(isParamNode(val)){
+    const [sendVal, sendPath] = (function () {
+        if (isParamNode(val)) {
             return [val, path]
         }
-        else if(endpoint.apiVersion){
+        else if (endpoint.apiVersion) {
             const [name, splitPath] = getLastPathPart(path);
-            return [{[name]: val}, splitPath];
+            return [{ [name]: val }, splitPath];
         }
         else {
-            return [{value: val}, path];
+            return [{ value: val }, path];
         }
     })();
-    try{
+    try {
         const response = await endpoint.put(sendVal, sendPath);
         endpoint.mergeData(response, sendPath);
-    }catch (err){
+    } catch (err) {
         console.debug("Error in PUT occured in WithEndpoint component", err);
     }
 }
 
-export function useRequestHandler<PreArgs extends unknown[], PostArgs extends unknown[]>(
+function useRequestHandler<PreArgs extends unknown[], PostArgs extends unknown[]>(
     { endpoint, fullpath, value, disabled,
         pre_method, pre_args,
-        post_method, post_args } : EndpointProps<PreArgs, PostArgs>
+        post_method, post_args }: EndpointProps<PreArgs, PostArgs>
 ): RequestHandler {
 
     const [isPending, startTransition] = useTransition();
-
+    const {setError} = useError();
     const data: ParamTree = value ?? getValueFromPath(endpoint.data, fullpath);
-    const metadata: MetadataValue = getValueFromPath<MetadataValue>(endpoint.metadata, fullpath)
-                                        ?? {value: data,
-                                            type: typeof data == "number" ? "int" : "str",
-                                            writeable: true};
+    const metadata: MetadataValue = getValueFromPath(endpoint.metadata, fullpath)
+        ?? {
+            value: data,
+        type: typeof data == "number" ? "int" : "str",
+        writeable: true
+    };
 
     const disable = disabled || isPending || endpoint.loading || !(metadata.writeable ?? true);
 
-    const requestHandler: RequestHandler["requestHandler"] = (val) => {
-        startTransition(async () => {
+    const type: dataTypes = useMemo(() => {
+        if (isMetadataValue(metadata)) {
+            switch (metadata.type) {
+                case "int":
+                case "float":
+                case "complex":
+                    return "number";
+                case "list":
+                case "tuple":
+                case "range":
+                    return "list"
+                case "bool":
+                    return "boolean"
+                case "str":
+                    return "string"
+                case "NoneType":
+                    return "null"
+                default:
+                    return metadata.type as dataTypes;
+            }
+        } else {
+            const dataType = typeof data;
+            switch (dataType) {
+                case "bigint":
+                case "number":
+                    return "number";
+                case "object":
+                    switch (true) {
+                        case data instanceof Array:
+                            return "list";
+                        case data == null:
+                            return "null";
+                        default:
+                            return "dict";
+                    }
+                case "boolean":
+                case "string":
+                    return dataType;
+                case "undefined":
+                default:
+                    console.warn(`Invalid Data type ${typeof data} for path ${fullpath}`)
+                    return "null";
+            }
+        }
 
-            pre_method?.(...(pre_args ?? []) as PreArgs);
+    }, [metadata, data]);
 
-            sendRequest(val ?? data, endpoint, fullpath)
-            .then(() => {
-                post_method?.(...(post_args ?? []) as PostArgs);
-            });
-        })
+    const validate = (val: typeof data) => {
+        switch (type) {
+            case "number":
+                val = Number(val);
+                break;
+            case "boolean":
+                if (typeof val === "string" && val.toLowerCase() === "false") {
+                    val = false;
+                } else {
+                    val = Boolean(val);
+                }
+                break;
+            case "list":
+                if (typeof val === "string") {
+                    val = val.split(",");
+                }
+                break;
+            case "string":
+                val = String(val);
+                break;
+        }
+
+        if (isMetadataValue(metadata)) {
+            if (metadata.allowed_values && !(metadata.allowed_values.includes(val))) {
+                throw Error(`Value ${val} not in allowed_values list: [${metadata.allowed_values.join(", ")}]`);
+            }
+            if (typeof val === "number") {
+                if (metadata.min != undefined && metadata.min > val) {
+                    throw Error(`Value ${val} below minimum ${metadata.min}`);
+                }
+                if (metadata.max != undefined && metadata.max < val) {
+                    throw Error(`Value ${val} above maximum ${metadata.max}`);
+                }
+            }
+        }
+
+        return val;
     }
 
-    return {requestHandler, data, disable}
+    const requestHandler: RequestHandler["requestHandler"] = (val) => {
+        try {
+            val = validate(val);
+            startTransition(async () => {
+
+                pre_method?.(...(pre_args ?? []) as PreArgs);
+
+                sendRequest(val ?? data, endpoint, fullpath)
+                    .then(() => {
+                        post_method?.(...(post_args ?? []) as PostArgs);
+                    });
+            })
+        } catch (err) {
+            setError(err instanceof Error ? err : Error("Unknown Error Occurred"));
+        }
+    }
+
+    return { requestHandler, data, disable }
 
 }
 
+export { sendRequest, useRequestHandler };

--- a/lib/components/WithEndpoint/util.ts
+++ b/lib/components/WithEndpoint/util.ts
@@ -74,7 +74,7 @@ export function useRequestHandler<PreArgs extends unknown[], PostArgs extends un
                                             type: typeof data == "number" ? "int" : "str",
                                             writeable: true};
 
-    const disable = disabled || isPending || endpoint.loading || !(metadata.writeable);
+    const disable = disabled || isPending || endpoint.loading || !(metadata.writeable ?? true);
 
     const requestHandler: RequestHandler["requestHandler"] = (val) => {
         startTransition(async () => {

--- a/lib/components/WithEndpoint/util.ts
+++ b/lib/components/WithEndpoint/util.ts
@@ -1,0 +1,55 @@
+import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
+import { isParamNode } from "../AdapterEndpoint";
+
+
+export interface EndpointProps<PreArgs extends unknown[], PostArgs extends unknown[]> {
+    endpoint: AdapterEndpoint;
+    fullpath: string;
+    value?: ParamTree;
+    min?: number;
+    max?: number;
+    disabled?: boolean;
+    pre_method?: (...args: PreArgs) => void;
+    post_method?: (...args: PostArgs) => void;
+    pre_args?: PreArgs;
+    post_args?: PostArgs;
+}
+
+const getLastPathPart = (path: string): [string, string] => {
+    const splitPath = path.replace(/\/$/, "").split("/");
+    const name = splitPath.pop() ?? "";
+
+    return [name, splitPath.join("/")];
+
+}
+
+/**
+ * Handles PUT requests for WithEndpoint components. Checks versioning of Odin Control
+ * to ensure proper PUT data layout (Odin Control 2.0 can accept PUTs of {"value": val})
+ * to avoid returning more of the tree than required.
+ * @param val Value to PUT to the adapter.
+ * @param endpoint AdapterEndpoint to handle the PUT request
+ * @param path Path to the parameter
+ */
+export async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoint, path: string): Promise<void> {
+
+    const [sendVal, sendPath] = (function() {
+        if(isParamNode(val)){
+            return [val, path]
+        }
+        else if(endpoint.apiVersion){
+            const [name, splitPath] = getLastPathPart(path);
+            return [{[name]: val}, splitPath];
+        }
+        else {
+            return [{value: val}, path];
+        }
+    })();
+    try{
+        const response = await endpoint.put(sendVal, sendPath);
+        endpoint.mergeData(response, sendPath);
+    }catch (err){
+        console.debug("Error in PUT occured in WithEndpoint component", err);
+    }
+}
+

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,7 +8,7 @@ export { OdinLiveView, ZoomableImage } from './components/OdinLiveView';
 export { OdinTable, OdinTableRow } from './components/OdinTable';
 export { ParamController } from './components/ParamController';
 export { TitleCard } from './components/TitleCard';
-export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, WithEndpoint } from './components/WithEndpoint';
+export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, EndpointSlider, WithEndpoint } from './components/WithEndpoint';
 
 export type { AdapterEndpoint, ParamNode, ParamTree } from "./components/AdapterEndpoint";
 export type { AdapterEndpoint_t } from "./components/AdapterEndpoint/AdapterEndpoint.types";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -8,7 +8,7 @@ export { OdinLiveView, ZoomableImage } from './components/OdinLiveView';
 export { OdinTable, OdinTableRow } from './components/OdinTable';
 export { ParamController } from './components/ParamController';
 export { TitleCard } from './components/TitleCard';
-export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, EndpointSlider, WithEndpoint } from './components/WithEndpoint';
+export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, EndpointSlider, EndpointDoubleSlider, WithEndpoint } from './components/WithEndpoint';
 
 export type { AdapterEndpoint, ParamNode, ParamTree } from "./components/AdapterEndpoint";
 export type { AdapterEndpoint_t } from "./components/AdapterEndpoint/AdapterEndpoint.types";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,17 +1,17 @@
 export { useAdapterEndpoint } from './components/AdapterEndpoint';
-export { WithEndpoint, EndpointInput, EndpointButton, EndpointDropdown, EndpointCheckbox } from './components/WithEndpoint';
-export { TitleCard } from './components/TitleCard';
 export { OdinApp } from './components/OdinApp';
+export { OdinDoubleSlider } from './components/OdinDoubleSlider';
+export { OdinErrorContext, OdinErrorOutlet, useError } from './components/OdinErrorContext';
+export { OdinEventLog } from './components/OdinEventLog';
 export { OdinGraph } from './components/OdinGraph';
-export {OdinTable, OdinTableRow } from './components/OdinTable';
-export {OdinEventLog} from './components/OdinEventLog';
-export {OdinErrorContext, OdinErrorOutlet, useError } from './components/OdinErrorContext';
-export {OdinDoubleSlider} from './components/OdinDoubleSlider';
 export { OdinLiveView, ZoomableImage } from './components/OdinLiveView';
+export { OdinTable, OdinTableRow } from './components/OdinTable';
 export { ParamController } from './components/ParamController';
+export { TitleCard } from './components/TitleCard';
+export { EndpointButton, EndpointCheckbox, EndpointDropdown, EndpointInput, WithEndpoint } from './components/WithEndpoint';
 
-export type { GraphData, Axis } from './components/OdinGraph';
 export type { AdapterEndpoint, ParamNode, ParamTree } from "./components/AdapterEndpoint";
 export type { AdapterEndpoint_t } from "./components/AdapterEndpoint/AdapterEndpoint.types";
 export type { Log } from './components/OdinEventLog';
+export type { Axis, GraphData } from './components/OdinGraph';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odin-react",
   "private": true,
-  "version": "2.0.6",
+  "version": "2.1.0",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -79,7 +79,7 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                                 post_method={secondTestFunc}>
                                 Trigger New Button
                             </EndpointButton>
-                            <EndpointInput endpoint={endpoint} fullpath="num_val" type="number"/>
+                            <EndpointInput endpoint={endpoint} fullpath="num_val"/>
                             <EndpointCheckbox type="switch" endpoint={endpoint} fullpath="toggle"/>
                         </Stack>
                     </TitleCard>
@@ -94,6 +94,9 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                         <Alert>Is Even: {endpoint.data.data?.dict?.is_even?.toString()}</Alert>
                         <EndpointButton endpoint={endpoint} fullpath="trigger" value={10} disabled={endpoint.data.data?.dict.is_even}>
                                     Disabled on Even
+                        </EndpointButton>
+                        <EndpointButton endpoint={endpoint} fullpath="num_val">
+                            Click For Num Val
                         </EndpointButton>
                     </TitleCard>
                 </Col>
@@ -175,9 +178,6 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                     <EndpointButton endpoint={endpoint} fullpath="submit" value={formData}>
                     Submit Form Data 
                     </EndpointButton>
-                    <NewEndpointButton endpoint={endpoint} fullpath="submit" value={formData}>
-                        Submit Form New Button
-                    </NewEndpointButton>
                 </TitleCard>
                 </Col>
                 <Col>

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -1,6 +1,6 @@
 import { Container, Row, Col, Stack, Form, InputGroup, Alert, Dropdown, FloatingLabel } from "react-bootstrap"
 import { TitleCard, WithEndpoint, OdinDoubleSlider } from "../"
-import { EndpointInput, EndpointButton, EndpointDropdown, EndpointCheckbox } from "../";
+import { EndpointInput, EndpointSlider, EndpointButton, EndpointDropdown, EndpointCheckbox } from "../";
 import type { ParamNode, Log} from "../";
 import { useState } from "react";
 import { AdapterEndpoint } from "../";
@@ -8,7 +8,7 @@ import { AdapterEndpoint } from "../";
 import type { ReactNode } from "react";
 
 const OldEndpointInput = WithEndpoint(Form.Control);
-const EndpointSlider = WithEndpoint(OdinDoubleSlider);
+const EndpointDoubleSlider = WithEndpoint(OdinDoubleSlider);
 const EndpointSelect = WithEndpoint((props: React.HTMLAttributes<HTMLSelectElement>) => (<select {...props}>{props.children as ReactNode}</select>))
 
 interface FormData_T extends ParamNode{
@@ -77,6 +77,7 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                                 Trigger New Button
                             </EndpointButton>
                             <EndpointInput endpoint={endpoint} fullpath="num_val"/>
+                            <EndpointSlider endpoint={endpoint} fullpath="num_val"/>
                             <OldEndpointInput endpoint={endpoint} fullpath="num_val" type="number"/>
                             <EndpointCheckbox type="switch" label="Toggle" endpoint={endpoint} fullpath="toggle"/>
                             <EndpointCheckbox type="checkbox" label="Toggle" endpoint={endpoint} fullpath="toggle"/>
@@ -200,7 +201,7 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                 <Col>
                 <TitleCard title="Slider">
                     <OdinDoubleSlider title="Test" showMinMaxValues={false}/>
-                    <EndpointSlider title="Endpoint Slider" endpoint={endpoint} fullpath="data/clip_data" min={-20} max={20} step={0.5}/>
+                    <EndpointDoubleSlider title="Endpoint Slider" endpoint={endpoint} fullpath="data/clip_data" min={-20} max={20} step={0.5}/>
                     <OdinDoubleSlider showTooltip={false} showMinMaxValues={true}/>
                     <OdinDoubleSlider showMinMaxValues={false}/>
                     <OdinDoubleSlider/>

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -60,14 +60,24 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
     const [input, changeInput] = useState(0);
     const [formData, changeFormData] = useState<FormData_T>({first_name: "", last_name: "", age: 0});
 
+    const testFunc = (comment: string) => {
+        console.log(comment);
+    }
+
+    const secondTestFunc = () => {
+        console.log("Second Test Funciton");
+    }
+
     return (
         <Container>
             <Row>
                 <Col>
                     <TitleCard title="Click Button">
                         <Stack>
-                            <EndpointButton endpoint={endpoint} fullpath="trigger" value={42}>
-                                Trigger
+                            <EndpointButton endpoint={endpoint} fullpath="trigger" value={42}
+                                pre_method={testFunc} pre_args={["Hello World"]}
+                                post_method={secondTestFunc}>
+                                Trigger New Button
                             </EndpointButton>
                             <EndpointInput endpoint={endpoint} fullpath="num_val" type="number"/>
                             <EndpointCheckbox type="switch" endpoint={endpoint} fullpath="toggle"/>
@@ -165,6 +175,9 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                     <EndpointButton endpoint={endpoint} fullpath="submit" value={formData}>
                     Submit Form Data 
                     </EndpointButton>
+                    <NewEndpointButton endpoint={endpoint} fullpath="submit" value={formData}>
+                        Submit Form New Button
+                    </NewEndpointButton>
                 </TitleCard>
                 </Col>
                 <Col>

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -77,6 +77,7 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                                 Trigger New Button
                             </EndpointButton>
                             <EndpointInput endpoint={endpoint} fullpath="num_val"/>
+                            <Form.Label>{`Slider Val: ${endpoint.data.num_val ?? "Unknown"}`}</Form.Label>
                             <EndpointSlider endpoint={endpoint} fullpath="num_val"/>
                             <OldEndpointInput endpoint={endpoint} fullpath="num_val" type="number"/>
                             <EndpointCheckbox type="switch" label="Toggle" endpoint={endpoint} fullpath="toggle"/>

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -7,11 +7,8 @@ import { AdapterEndpoint } from "../";
 
 import type { ReactNode } from "react";
 
-// const EndpointInput = WithEndpoint(Form.Control);
-// const EndpointButton = WithEndpoint(Button);
-// const EndpointDropdown = WithEndpoint(DropdownButton);
+const OldEndpointInput = WithEndpoint(Form.Control);
 const EndpointSlider = WithEndpoint(OdinDoubleSlider);
-// const EndpointCheckbox = WithEndpoint(Form.Check);
 const EndpointSelect = WithEndpoint((props: React.HTMLAttributes<HTMLSelectElement>) => (<select {...props}>{props.children as ReactNode}</select>))
 
 interface FormData_T extends ParamNode{
@@ -80,7 +77,9 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                                 Trigger New Button
                             </EndpointButton>
                             <EndpointInput endpoint={endpoint} fullpath="num_val"/>
-                            <EndpointCheckbox type="switch" endpoint={endpoint} fullpath="toggle"/>
+                            <OldEndpointInput endpoint={endpoint} fullpath="num_val" type="number"/>
+                            <EndpointCheckbox type="switch" label="Toggle" endpoint={endpoint} fullpath="toggle"/>
+                            <EndpointCheckbox type="checkbox" label="Toggle" endpoint={endpoint} fullpath="toggle"/>
                         </Stack>
                     </TitleCard>
                 </Col>
@@ -121,7 +120,15 @@ export const EndpointPage: React.FC<{endpoint: AdapterEndpoint<EndpointData>}> =
                             </EndpointSelect>
                         </label>
 
-                        <EndpointInput endpoint={endpoint} fullpath="deep/long/nested/dict/path/val" />
+                        <Form>
+                            <EndpointCheckbox endpoint={endpoint} fullpath={"selected"}
+                                type="radio" name="radio-group" value="item 1" label="Item One"/>
+                            <EndpointCheckbox endpoint={endpoint} fullpath={"selected"}
+                                type="radio" name="radio-group" value="item 2" label="Item Two"/>
+                            <EndpointCheckbox endpoint={endpoint} fullpath={"selected"}
+                                type="radio" name="radio-group" value="item 3" label="Item Three"/>
+                        </Form>
+
                         </Stack>
                     </TitleCard>
                 </Col>

--- a/src/EndpointPage.tsx
+++ b/src/EndpointPage.tsx
@@ -1,6 +1,6 @@
 import { Container, Row, Col, Stack, Form, InputGroup, Alert, Dropdown, FloatingLabel } from "react-bootstrap"
 import { TitleCard, WithEndpoint, OdinDoubleSlider } from "../"
-import { EndpointInput, EndpointSlider, EndpointButton, EndpointDropdown, EndpointCheckbox } from "../";
+import { EndpointInput, EndpointSlider, EndpointDoubleSlider, EndpointButton, EndpointDropdown, EndpointCheckbox } from "../";
 import type { ParamNode, Log} from "../";
 import { useState } from "react";
 import { AdapterEndpoint } from "../";
@@ -8,7 +8,6 @@ import { AdapterEndpoint } from "../";
 import type { ReactNode } from "react";
 
 const OldEndpointInput = WithEndpoint(Form.Control);
-const EndpointDoubleSlider = WithEndpoint(OdinDoubleSlider);
 const EndpointSelect = WithEndpoint((props: React.HTMLAttributes<HTMLSelectElement>) => (<select {...props}>{props.children as ReactNode}</select>))
 
 interface FormData_T extends ParamNode{


### PR DESCRIPTION
Add support ready for the release of [Odin Control 2.0](https://github.com/odin-detector/odin-control/issues/62).
- AdapterEndpoints now check if they require the API version number in the URL
- WithEndpoint components use the `{value: val}` pattern for PUT requests if using Odin Control 2.0
- rewritten the default WithEndpoint components to be more specific, avoiding complication due to using the generic WIthEndpoint HOC
- Added EndpointSlider and EndpointDoubleSlider to the library of default WithEndpoint components

closes #96 