### PR TITLE
Feature/with endpoint updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin React
 ![GitHub package.json version](https://img.shields.io/github/package-json/v/stfc-aeg/odin-react)
-![GitHub package.json dev/peer/optional dependency version](https://img.shields.io/github/package-json/dependency-version/stfc-aeg/odin-react/peer/react)
+![GitHub package.json prod dependency version](https://img.shields.io/github/package-json/dependency-version/stfc-aeg/odin-react/react)
 ![GitHub package.json dev/peer/optional dependency version](https://img.shields.io/github/package-json/dependency-version/stfc-aeg/odin-react/dev/vite)
 
 Component Library designed for Odin Control Interfaces, build with [Vite](https://vite.dev/)

--- a/docs/Introduction.mdx
+++ b/docs/Introduction.mdx
@@ -11,7 +11,7 @@ import "./storydocs.css"
         # Welcome to Odin React
         ![Test Odin React](https://github.com/stfc-aeg/odin-react/actions/workflows/test-ui.yml/badge.svg)
         ![GitHub package.json version](https://img.shields.io/github/package-json/v/stfc-aeg/odin-react)
-        ![GitHub package.json dev/peer/optional dependency version](https://img.shields.io/github/package-json/dependency-version/stfc-aeg/odin-react/peer/react)
+        ![GitHub package.json prod dependency version](https://img.shields.io/github/package-json/dependency-version/stfc-aeg/odin-react/react)
         ![GitHub package.json dev/peer/optional dependency version](https://img.shields.io/github/package-json/dependency-version/stfc-aeg/odin-react/dev/vite)
 
         Odin React is a [React](https://react.dev/) package designed to make the
@@ -62,7 +62,7 @@ import "./storydocs.css"
             Vite's compilation step bundles source code, image assets, and any
             dependencies together into a minified static web resource.
 
-            <a className="sb-action-link" href="https://react.dev/" target="_blank"
+            <a className="sb-action-link" href="https://vite.dev/" target="_blank"
             >Learn more ></a>
         </Col>
 

--- a/docs/demoPage.tsx
+++ b/docs/demoPage.tsx
@@ -24,7 +24,7 @@ const DemoPage = (
         changeMessage("Trigger Clicked\nAwaiting Data");
     }
 
-    const PostMethod = (num: number) => {
+    const PostMethod = ({num}: {num: number}) => {
         changeMessage("Post Method\nNumber: " + num);
     }
 
@@ -41,7 +41,7 @@ const DemoPage = (
                                 <InputGroup.Text>Trigger</InputGroup.Text>
                                 <EndpointButton endpoint={endpoint} fullpath='trigger' value={42}
                                     pre_method={PreMethod} post_method={PostMethod}
-                                    post_args={[endpoint.data.rand_num]}>
+                                    post_args={{num: endpoint.data.rand_num}}>
                                     Click me!
                                 </EndpointButton>
                                 <Form.Control as="textarea" readOnly value={triggeredStateMessage} />

--- a/lib/components/AdapterEndpoint/index.mock.tsx
+++ b/lib/components/AdapterEndpoint/index.mock.tsx
@@ -35,6 +35,7 @@ export interface EndpointData extends actual.ParamNode {
             }
         }
     };
+    volt: number;
     graph_data: number[];
 }
 
@@ -78,7 +79,8 @@ const testAdapterData: EndpointData = {
     selected: "item 1",
     toggle: true,
     trigger: null,
-    graph_data: Array.from(Array(360), (_, x) => Math.sin(x * (Math.PI / 180)))
+    graph_data: Array.from(Array(360), (_, x) => Math.sin(x * (Math.PI / 180))),
+    volt: 1500
 }
 
 const testLiveData: LiveViewData = {
@@ -101,7 +103,8 @@ const metadataPaths: { [key: string]: Partial<MetadataValue> } = {
     "num_val": { min: 10, max: 90 },
     "clip_data": {min: -25, max: 25},
     "rand_num": { writeable: false },
-    "dict": { writeable: false, type: "dict" }
+    "dict": { writeable: false, type: "dict" },
+    "volt": {min: 100, max: 5000, units: "mV", name: "Voltage" }
 }
 
 const testMetadata = createMetadata(testAdapterData, metadataPaths);

--- a/lib/components/AdapterEndpoint/index.mock.tsx
+++ b/lib/components/AdapterEndpoint/index.mock.tsx
@@ -246,7 +246,7 @@ const transformMockCode = async (source: string, _?: StoryContext, adapterName: 
         ret_string = [addEndpointString,
             "",
             "return (",
-            source.replace(/endpoint={{[\s\S]*updateFlag: Symbol\(mocked\)\s*}}/, ` endpoint={endpoint}`),
+            source.replaceAll(/endpoint={{[\s\S]*?updateFlag: Symbol\(mocked\),?\s*}}/g, ` endpoint={endpoint}`),
             ")"].join("\n");
     }
 

--- a/lib/components/WithEndpoint/EndpointButton.stories.tsx
+++ b/lib/components/WithEndpoint/EndpointButton.stories.tsx
@@ -88,13 +88,13 @@ export const DisabledBecauseParam: Story = {
 export const PreTrigger: Story = {
   args: {
     pre_method: fn(),
-    pre_args: ["Pre Function Arg"]
+    pre_args: {message: "Pre Function Args"}
   },
   play: async ({canvas, args, userEvent}) => {
     const put = spyOn(args.endpoint, "put").mockName("endpoint.put");
     await userEvent.click(canvas.getByRole("button"));
 
-    await expect(args.pre_method).toHaveBeenCalledWith(...(args.pre_args as string[]));
+    await expect(args.pre_method).toHaveBeenCalledWith(args.pre_args);
     await expect(put).toHaveBeenCalled();
   }
 }

--- a/lib/components/WithEndpoint/EndpointButton.stories.tsx
+++ b/lib/components/WithEndpoint/EndpointButton.stories.tsx
@@ -2,10 +2,21 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { EndpointButton } from './EndpointButton';
 
-import { fn, expect, spyOn } from 'storybook/test';
+import { fn, expect, spyOn, Mock } from 'storybook/test';
 
 // Mocked Endpoint
 import { useAdapterEndpoint, transformMockCode } from '../AdapterEndpoint/index.mock';
+
+type testMethodProps = {
+  value?: number;
+  message: string;
+}
+
+const testPreMethod = ({value, message}: testMethodProps) => {
+  console.log(message);
+ 
+  return (value ?? 0) * 2;
+}
 
 const meta = {
   component: EndpointButton,
@@ -43,9 +54,47 @@ const meta = {
   }
 } satisfies Meta<typeof EndpointButton>;
 
+const metaWithFunc = {
+  component: (EndpointButton<testMethodProps, undefined>),
+  args: {
+    endpoint: undefined,
+    fullpath: "trigger",
+  },
+  argTypes: {
+    endpoint: {
+      control: {
+        disable: true
+      }
+    },
+    value: {
+      table: {
+        type: {
+          summary: "ParamTree",
+          detail: "String, Number, Boolean, null/undefined, or an array or dict of those values"
+        }
+      }
+    },
+  },
+  parameters: {
+    layout: "centered",
+    docs: {
+      source: {
+        transform: transformMockCode,
+        language: "tsx"
+      }
+    },
+  },
+  render: (args) => {
+    args.endpoint = useAdapterEndpoint("test", "http://localhost:1338");
+    return <EndpointButton {...args}>Test Button: {args.fullpath}</EndpointButton>
+  }
+} satisfies Meta<typeof EndpointButton<testMethodProps, undefined>>;
+
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+type StoryWithFunc = StoryObj<typeof metaWithFunc>;
 
 /** Standard use of the EndpointButton. */
 export const Default: Story = {
@@ -57,7 +106,6 @@ export const Default: Story = {
     const put = spyOn(args.endpoint, "put").mockName("endpoint.put");
     await userEvent.click(canvas.getByRole("button"));
 
-    await expect(put).toHaveBeenCalled();
     await expect(put).toHaveBeenCalledWith({value: true}, "trigger");
     await expect(put).toHaveReturnedWith({value: null});
   }
@@ -84,17 +132,31 @@ export const DisabledBecauseParam: Story = {
   }
 }
 
-/** The Button can be provided a function (and optional args) */
-export const PreTrigger: Story = {
+/** 
+ * The Button can be provided a function (and optional args). This function
+ * can receive the Param value; and if its the pre_method, can return a value
+ * to send via the PUT request instead of the original value (so it may modify
+ * the value before sending) */
+export const PreTrigger: StoryWithFunc = {
   args: {
-    pre_method: fn(),
-    pre_args: {message: "Pre Function Args"}
+    value: 12,
+    pre_method: fn(testPreMethod),
+    post_method: fn(() => {console.log("Post Method without Args")}),
+    pre_args: { value: undefined, message: "Pre Function" }
   },
   play: async ({canvas, args, userEvent}) => {
     const put = spyOn(args.endpoint, "put").mockName("endpoint.put");
     await userEvent.click(canvas.getByRole("button"));
 
     await expect(args.pre_method).toHaveBeenCalledWith(args.pre_args);
-    await expect(put).toHaveBeenCalled();
+    await expect(put).toHaveBeenCalledWith({"value": 24}, "trigger");
+    await expect(args.post_method).toHaveBeenCalled();
+    
+    // ensuring order of pre/post methods and put method
+    const pre_order = (args.pre_method as Mock<typeof testPreMethod>).mock.invocationCallOrder[0];
+    const put_order = put.mock.invocationCallOrder[0];
+    const post_order = (args.post_method as Mock<() => void>).mock.invocationCallOrder[0];
+    await expect(pre_order).toBeLessThan(put_order);
+    await expect(put_order).toBeLessThan(post_order);
   }
 }

--- a/lib/components/WithEndpoint/EndpointButton.tsx
+++ b/lib/components/WithEndpoint/EndpointButton.tsx
@@ -1,10 +1,10 @@
 import type { ButtonProps } from "react-bootstrap";
 import { Button } from "react-bootstrap";
 
-import type { EndpointProps } from "./util";
+import type { EndpointProps, ArgType } from "./util";
 import { useRequestHandler } from "./util";
 
-type EndpointButtonProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type EndpointButtonProps<PreArgs extends ArgType, PostArgs extends ArgType> =
     EndpointProps<PreArgs, PostArgs> & Omit<ButtonProps, keyof EndpointProps<PreArgs, PostArgs>>;
 
 
@@ -20,7 +20,7 @@ type EndpointButtonProps<PreArgs extends unknown[], PostArgs extends unknown[]> 
  * PUTs the value prop if supplied, otherwise PUTs whatever the parameter is
  * on the Tree.
  */
-const EndpointButton = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointButton = <PreArgs extends ArgType, PostArgs extends ArgType>(
     { endpoint, fullpath, value, disabled,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/EndpointCheckbox.tsx
+++ b/lib/components/WithEndpoint/EndpointCheckbox.tsx
@@ -6,7 +6,7 @@ import { useRequestHandler } from "./util";
 
 import style from './styles.module.css'
 
-type EndpointCheckboxProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type EndpointCheckboxProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
     EndpointProps<PreArgs, PostArgs> & Omit<FormCheckProps, keyof EndpointProps<PreArgs, PostArgs>>;
 
 
@@ -19,7 +19,7 @@ type EndpointCheckboxProps<PreArgs extends unknown[], PostArgs extends unknown[]
  * Based on the [Bootstrap FormCheck](https://react-bootstrap.netlify.app/docs/forms/checks-radios),
  * so all props available on that component can be set here.
  */
-const EndpointCheckbox = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointCheckbox = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
     { endpoint, fullpath, value, disabled,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/EndpointDoubleSlider.tsx
+++ b/lib/components/WithEndpoint/EndpointDoubleSlider.tsx
@@ -6,7 +6,7 @@ import { ComponentProps, useRef, useState, useEffect } from "react";
 import { getValueFromPath } from "../AdapterEndpoint";
 import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 
-type EndpointDoubleSliderProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type EndpointDoubleSliderProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
     EndpointProps<PreArgs, PostArgs> & SliderProps;
 
 /**
@@ -19,7 +19,7 @@ type EndpointDoubleSliderProps<PreArgs extends unknown[], PostArgs extends unkno
  * Designed to be used with a Parameter that represents a min and max
  * value of some sort as a pair of numbers in an array.
  */
-const EndpointDoubleSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointDoubleSlider = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
     { endpoint, fullpath, value, disabled, min, max,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/EndpointDropdown.tsx
+++ b/lib/components/WithEndpoint/EndpointDropdown.tsx
@@ -5,7 +5,7 @@ import { useRequestHandler } from "./util";
 import { getValueFromPath } from "../AdapterEndpoint";
 import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 
-type EndpointDropdownProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type EndpointDropdownProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
     EndpointProps<PreArgs, PostArgs> & Partial<DropdownButtonProps>;
 
 
@@ -19,7 +19,7 @@ type EndpointDropdownProps<PreArgs extends unknown[], PostArgs extends unknown[]
  * Based on the [Bootstrap DropdownButton](https://react-bootstrap.netlify.app/docs/components/dropdowns),
  * so any props on that component can also be set here.
  */
-const EndpointDropdown = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointDropdown = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
     { endpoint, fullpath, value, disabled,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/EndpointInput.stories.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.stories.tsx
@@ -60,7 +60,7 @@ export const Default: Story = {
 
     await userEvent.clear(input);
     await userEvent.type(input, "52");
-    await expect(put).not.toHaveBeenCalled();
+    await expect(put).not.toHaveBeenCalledWith({ value: "52" }, "string_val");
     await userEvent.keyboard("[Enter]");
     await expect(put).toHaveBeenCalledWith({ value: "52" }, "string_val");
   }

--- a/lib/components/WithEndpoint/EndpointInput.stories.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { EndpointInput } from './EndpointInput';
 import { useAdapterEndpoint, resetMockData, transformMockCode } from '../AdapterEndpoint/index.mock';
-import { expect, spyOn } from 'storybook/test';
+import { expect, spyOn, fn } from 'storybook/test';
 
 const meta = {
   component: EndpointInput,
@@ -60,7 +60,7 @@ export const Default: Story = {
 
     await userEvent.clear(input);
     await userEvent.type(input, "52");
-    await expect(put).not.toHaveBeenCalledWith({ value: "52" }, "string_val");
+    await expect(put).not.toHaveBeenCalled();
     await userEvent.keyboard("[Enter]");
     await expect(put).toHaveBeenCalledWith({ value: "52" }, "string_val");
   }
@@ -85,6 +85,39 @@ export const Number: Story = {
   }
 }
 
+const preCapMethod = ({value}: {value?: string}) => {
+  console.log(`Pre Func called with ${value}`);
+  return value?.toUpperCase();
+}
+
+/** We can manipulate the sent string/number value with the pre_method */
+export const PreCapitalise: Story = {
+  args: {
+    pre_method: fn(preCapMethod),
+    pre_args: {value: undefined}
+  },
+  play: async({args, canvas, userEvent}) => {
+    const put = spyOn(args.endpoint, "put").mockName("endpoint.put");
+    const input = canvas.getByRole("textbox");
+    const put_string = "new value";
+
+    await expect(input).toHaveDisplayValue(args.endpoint.data.string_val as string);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, put_string);
+
+    await expect(put).not.toHaveBeenCalled();
+    await userEvent.keyboard("[Enter]");
+
+    await expect(args.pre_method).toHaveBeenCalledWith({value: put_string});
+    await expect(put).toHaveBeenCalledWith({"value": put_string.toUpperCase()}, args.fullpath);
+    await expect(input).toHaveDisplayValue(put_string.toUpperCase());
+
+
+  }
+}
+
+/** Input will be readonly if the parameter is not writeable */
 export const ReadOnly: Story = {
   args: {
     fullpath: "rand_num"

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -7,7 +7,7 @@ import type { MetadataValue } from '../AdapterEndpoint/AdapterEndpoint.types';
 import { useRequestHandler, type EndpointProps } from './util';
 
 
-type EndpointInputProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type EndpointInputProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
     EndpointProps<PreArgs, PostArgs> & Omit<FormControlProps, keyof EndpointProps<PreArgs, PostArgs>>;
 
 
@@ -21,7 +21,7 @@ type EndpointInputProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
  * 
  * Can be used for both string and number based Parameters.
  */
-const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointInput = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
     { endpoint, fullpath, value, disabled, min, max,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/EndpointInput.tsx
+++ b/lib/components/WithEndpoint/EndpointInput.tsx
@@ -78,7 +78,7 @@ const EndpointInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
 
     return (
         <Form.Control ref={component} onChange={onChangeHandler} onKeyUp={onEnterHandler} value={compVal}
-            min={compMin} max={compMax} disabled={disable} type={type} {...rest} style={style} />
+            min={compMin} max={compMax} disabled={disable} type={type} style={style} {...rest}  />
     )
 }
 

--- a/lib/components/WithEndpoint/EndpointRangeInput.stories.tsx
+++ b/lib/components/WithEndpoint/EndpointRangeInput.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { EndpointMultipliedInput } from './EndpointRangeInput';
+import { useAdapterEndpoint, resetMockData, transformMockCode } from '../AdapterEndpoint/index.mock';
+import { expect, spyOn } from 'storybook/test';
+
+const meta = {
+  component: EndpointMultipliedInput,
+  args: {
+    endpoint: undefined,
+    fullpath: "volt",
+    ranges: { "mV": 1, "V": 1e3, "μV": 1e-3 }
+  },
+  argTypes: {
+    endpoint: {
+      table: {
+        readonly: true
+      }
+    },
+    value: {
+      table: {
+        readonly: true
+      },
+      description: "Unused, will always read from Adapter instead to display Parameter"
+    }
+  },
+  parameters: {
+    docs: {
+      source: {
+        transform: transformMockCode,
+        language: "tsx"
+      }
+    }
+  },
+  render: (args) => {
+    args.endpoint = useAdapterEndpoint("test", "http://localhost:1338");
+    return <EndpointMultipliedInput {...args} />
+  },
+  beforeEach: async () => {
+    resetMockData();
+  },
+
+} satisfies Meta<typeof EndpointMultipliedInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Standard use, with Voltage options as a demonstration */
+export const Default: Story = {
+  args: {
+    step: 10
+  }
+};
+
+
+/** Can also be used with non-decimal ranges, such as seconds/minutes */
+export const Time: Story = {
+  args: {
+    ranges: {"Minutes": 60000, "s": 1000, "ms": 1},
+    fullpath: "data/set_data",
+    title: "Time"
+  }
+}

--- a/lib/components/WithEndpoint/EndpointRangeInput.stories.tsx
+++ b/lib/components/WithEndpoint/EndpointRangeInput.stories.tsx
@@ -9,7 +9,8 @@ const meta = {
   args: {
     endpoint: undefined,
     fullpath: "volt",
-    ranges: { "mV": 1, "V": 1e3, "μV": 1e-3 }
+    ranges: { "mV": 1e-3, "V": 1, "μV": 1e-6 },
+    defaultRange: "mV"
   },
   argTypes: {
     endpoint: {
@@ -48,8 +49,30 @@ type Story = StoryObj<typeof meta>;
 
 /** Standard use, with Voltage options as a demonstration */
 export const Default: Story = {
-  args: {
-    step: 10
+  args: {},
+  play: async ({args, canvas, userEvent}) => {
+    const put = spyOn(args.endpoint, "put").mockName("endpoint.put");
+    const input = canvas.getByRole("spinbutton");
+    const dropdown = canvas.getByRole("button");
+
+    await userEvent.clear(input);
+    await userEvent.type(input, "1600");
+
+    await userEvent.keyboard("[Enter]");
+    await expect(put).toHaveBeenCalledWith({value: 1600}, args.fullpath);
+
+    await userEvent.click(dropdown);
+    const VoltButton = canvas.getByText("V");
+
+    await userEvent.click(VoltButton);
+
+    await expect(input).toHaveDisplayValue("1.6");
+
+    await userEvent.clear(input);
+    await userEvent.type(input, "2");
+    await userEvent.keyboard("[Enter]");
+
+    await expect(put).toHaveBeenCalledWith({value: 2000}, args.fullpath);
   }
 };
 
@@ -57,7 +80,8 @@ export const Default: Story = {
 /** Can also be used with non-decimal ranges, such as seconds/minutes */
 export const Time: Story = {
   args: {
-    ranges: {"Minutes": 60000, "s": 1000, "ms": 1},
+    ranges: {"Minutes": 60, "s": 1, "ms": 1e-3},
+    defaultRange: "ms",
     fullpath: "data/set_data",
     title: "Time"
   }

--- a/lib/components/WithEndpoint/EndpointRangeInput.tsx
+++ b/lib/components/WithEndpoint/EndpointRangeInput.tsx
@@ -9,12 +9,20 @@ import { useRequestHandler, type EndpointProps } from './util';
 interface RangedAdditionalProps {
     /** 
      * Record of keys to display in the dropdown, and the corresponding
-     * value to multiply by if that option is selected.
+     * multiplication of that key. 
      * 
-     * 
-     * For example, for a Voltage param expecting V: {"V": 1, "kV": 1000, "mV": 1/1000}
+     * For example, for a Voltage parameter: {"V": 1, "kV": 1000, "mV": 1/1000}
      */
     ranges: Record<string, number>;
+
+    /**
+     * The default range of the input. Multiplication will be adjusted based off
+     * whatever the value of the default is
+     * 
+     * For example, if `ranges` is `{"V": 1, "kV": 1000, "mV": 1/1000}` and `default` is
+     * "mV", selecting "V" will multiply the parameter by 1000 before doing the PUT.
+     * */
+    defaultRange?: string;
     /** Minimum value of the input */
     min?: number;
     /** Maximum value of the input */
@@ -41,16 +49,20 @@ const EndpointMultipliedInput = <PreArgs extends Record<string, unknown>, PostAr
     { endpoint, fullpath, value, disabled, min, max,
         pre_method, pre_args,
         post_method, post_args,
-        ranges, title, step = 1,
+        defaultRange, ranges, title, step = 1,
         ...rest }: MultipliedInputProps<PreArgs, PostArgs>
 ) => {
 
     const { requestHandler, data: endVal, disable } = useRequestHandler({
         endpoint, fullpath, disabled, pre_method, pre_args, post_method, post_args
     });
+    /** base multiplication value. final value will be  */
+    const baseMult = defaultRange ??
+        Object.keys(ranges).find(key => ranges[key] === 1) ??
+        Object.keys(ranges)[0];
 
-    const [multiply, changeMultiply] = useState<string>(
-        Object.keys(ranges).find(key => ranges[key] === 1) ?? Object.keys(ranges)[0]);
+
+    const [multiply, changeMultiply] = useState(baseMult);
     const [compVal, changeCompVal] = useState<number>(0);
     const [editing, setEditing] = useState(false);
 
@@ -60,12 +72,13 @@ const EndpointMultipliedInput = <PreArgs extends Record<string, unknown>, PostAr
     const compMin = min ?? metaData?.min;
     const compMax = max ?? metaData?.max;
 
+    const adjustVal = ranges[multiply] / ranges[baseMult];
     const label = title || metaData?.name || fullpath.split("/").at(-1);
 
     const style: CSSProperties = editing ? { backgroundColor: "var(--bs-highlight-bg)" } : {};
 
     const onChangeHandler: FormControlProps["onChange"] = (event) => {
-        const val = (event.target as HTMLInputElement).valueAsNumber * ranges[multiply];
+        const val = (event.target as HTMLInputElement).valueAsNumber * adjustVal;
 
         changeCompVal(val);
 
@@ -101,10 +114,10 @@ const EndpointMultipliedInput = <PreArgs extends Record<string, unknown>, PostAr
             <InputGroup.Text>{label ?? "Value"}</InputGroup.Text>
             <Form.Control ref={component} type='number' style={style}
                 onChange={onChangeHandler} onKeyUp={onEnterHandler}
-                value={compVal / ranges[multiply]} disabled={disable}
-                min={compMin ? compMin / ranges[multiply] : undefined}
-                max={compMax ? compMax / ranges[multiply] : undefined}
-                step={step ? step / ranges[multiply] : undefined} />
+                value={compVal / adjustVal} disabled={disable}
+                min={compMin ? compMin / adjustVal : undefined}
+                max={compMax ? compMax / adjustVal : undefined}
+                step={step ? step / adjustVal : undefined} />
             <DropdownButton title={multiply} onSelect={onSelectHandler} disabled={disable}>
                 {Object.entries(ranges).sort((a, b) => a[1] - b[1]).map(
                     (selection) => (

--- a/lib/components/WithEndpoint/EndpointRangeInput.tsx
+++ b/lib/components/WithEndpoint/EndpointRangeInput.tsx
@@ -1,0 +1,123 @@
+import { ComponentProps, CSSProperties, useState, useEffect, useRef } from 'react';
+import type { InputGroupProps, FormControlProps } from 'react-bootstrap';
+import { Dropdown, DropdownButton, Form, InputGroup } from 'react-bootstrap';
+import { getValueFromPath } from '../AdapterEndpoint';
+import type { MetadataValue } from '../AdapterEndpoint/AdapterEndpoint.types';
+import { useRequestHandler, type EndpointProps } from './util';
+
+
+interface RangedAdditionalProps {
+    /** 
+     * Record of keys to display in the dropdown, and the corresponding
+     * value to multiply by if that option is selected.
+     * 
+     * 
+     * For example, for a Voltage param expecting V: {"V": 1, "kV": 1000, "mV": 1/1000}
+     */
+    ranges: Record<string, number>;
+    /** Minimum value of the input */
+    min?: number;
+    /** Maximum value of the input */
+    max?: number;
+    /** Specifies the granularity of the value */
+    step?: number;
+}
+
+type MultipliedInputProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    EndpointProps<PreArgs, PostArgs> & Omit<InputGroupProps, keyof EndpointProps<PreArgs, PostArgs>> &
+    RangedAdditionalProps;
+
+
+/**
+ * An Endpoint Input with an included multiplier/range dropdown, for Parameters
+ * that may have multiple scaling ranges such as Voltage, Amps, Seconds, etc.
+ * 
+ * Whilst the displayed value scales based on the selected range, the underlying
+ * value sent to the Adapter does not get altered. This is designed purely so that
+ * the user can more easily view and enter values that might have wide range
+ * options.
+ */
+const EndpointMultipliedInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    { endpoint, fullpath, value, disabled, min, max,
+        pre_method, pre_args,
+        post_method, post_args,
+        ranges, title, step = 1,
+        ...rest }: MultipliedInputProps<PreArgs, PostArgs>
+) => {
+
+    const { requestHandler, data: endVal, disable } = useRequestHandler({
+        endpoint, fullpath, disabled, pre_method, pre_args, post_method, post_args
+    });
+
+    const [multiply, changeMultiply] = useState<string>(
+        Object.keys(ranges).find(key => ranges[key] === 1) ?? Object.keys(ranges)[0]);
+    const [compVal, changeCompVal] = useState<number>(0);
+    const [editing, setEditing] = useState(false);
+
+    const component = useRef<HTMLInputElement>(null);
+
+    const metaData: MetadataValue | undefined = getValueFromPath(endpoint.metadata, fullpath);
+    const compMin = min ?? metaData?.min;
+    const compMax = max ?? metaData?.max;
+
+    const label = title || metaData?.name || fullpath.split("/").at(-1);
+
+    const style: CSSProperties = editing ? { backgroundColor: "var(--bs-highlight-bg)" } : {};
+
+    const onChangeHandler: FormControlProps["onChange"] = (event) => {
+        const val = (event.target as HTMLInputElement).valueAsNumber * ranges[multiply];
+
+        changeCompVal(val);
+
+        setEditing(!(val == endVal));
+    }
+
+    const onEnterHandler: FormControlProps["onKeyUp"] = (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+            console.debug(fullpath, event);
+            requestHandler(compVal);
+            setEditing(false);
+        }
+    }
+
+    const onSelectHandler: ComponentProps<typeof DropdownButton>["onSelect"] = (eventKey) => {
+
+        changeMultiply(eventKey!);
+    };
+
+    useEffect(() => {
+        //Endpoint Value changed, update component value if need be.
+        const newVal = getValueFromPath<number>(endpoint.data, fullpath);
+
+        // check if the component is not currently active
+        if (document.activeElement !== component.current && !editing && typeof newVal !== "undefined") {
+            changeCompVal(newVal);
+        }
+
+    }, [endpoint.updateFlag, endVal]);
+
+    return (
+        <InputGroup {...rest}>
+            <InputGroup.Text>{label ?? "Value"}</InputGroup.Text>
+            <Form.Control ref={component} type='number' style={style}
+                onChange={onChangeHandler} onKeyUp={onEnterHandler}
+                value={compVal / ranges[multiply]} disabled={disable}
+                min={compMin ? compMin / ranges[multiply] : undefined}
+                max={compMax ? compMax / ranges[multiply] : undefined}
+                step={step ? step / ranges[multiply] : undefined} />
+            <DropdownButton title={multiply} onSelect={onSelectHandler} disabled={disable}>
+                {Object.entries(ranges).sort((a, b) => a[1] - b[1]).map(
+                    (selection) => (
+                        <Dropdown.Item key={selection[1]} eventKey={selection[0]} active={selection[0] == multiply}>
+                            {selection[0]}
+                        </Dropdown.Item>
+                    )
+                )}
+            </DropdownButton>
+        </InputGroup>
+    )
+
+
+}
+
+export { EndpointMultipliedInput };

--- a/lib/components/WithEndpoint/EndpointRangeInput.tsx
+++ b/lib/components/WithEndpoint/EndpointRangeInput.tsx
@@ -23,7 +23,7 @@ interface RangedAdditionalProps {
     step?: number;
 }
 
-type MultipliedInputProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type MultipliedInputProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
     EndpointProps<PreArgs, PostArgs> & Omit<InputGroupProps, keyof EndpointProps<PreArgs, PostArgs>> &
     RangedAdditionalProps;
 
@@ -37,7 +37,7 @@ type MultipliedInputProps<PreArgs extends unknown[], PostArgs extends unknown[]>
  * the user can more easily view and enter values that might have wide range
  * options.
  */
-const EndpointMultipliedInput = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointMultipliedInput = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
     { endpoint, fullpath, value, disabled, min, max,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/EndpointSlider.tsx
+++ b/lib/components/WithEndpoint/EndpointSlider.tsx
@@ -13,7 +13,7 @@ interface  SliderAdditonalProps {
     tooltipPlacement?: OverlayTriggerProps["placement"];
 }
 
-type EndpointRangeProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+type EndpointRangeProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
     EndpointProps<PreArgs, PostArgs> & FormRangeProps & SliderAdditonalProps;
 
 type PutEvent = Parameters<Required<FormRangeProps>["onMouseUp"]>[0] 
@@ -31,7 +31,7 @@ type PutEvent = Parameters<Required<FormRangeProps>["onMouseUp"]>[0]
  * so all props available on that component can be set here.
  * 
  */
-const EndpointSlider = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+const EndpointSlider = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
     { endpoint, fullpath, value, disabled, min, max,
         pre_method, pre_args,
         post_method, post_args,

--- a/lib/components/WithEndpoint/index.tsx
+++ b/lib/components/WithEndpoint/index.tsx
@@ -45,11 +45,11 @@ const WithEndpoint = <P extends object>(WrappedComponent: React.FC<P>) => {
     /**
      * Combined Props for resulting WithEndpoint Component.
      * Combines {@link EndpointProps} with the props of whatever component is being wrapped.*/
-    type WrappedComponentProps<PreArgs extends unknown[], PostArgs extends unknown[]> =
+    type WrappedComponentProps<PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>> =
         EndpointProps<PreArgs, PostArgs> & P;
 
 
-    const WithEndpointComponent = <PreArgs extends unknown[], PostArgs extends unknown[]>(
+    const WithEndpointComponent = <PreArgs extends Record<string, unknown>, PostArgs extends Record<string, unknown>>(
         props: WrappedComponentProps<PreArgs, PostArgs>) => {
 
         const { endpoint, fullpath, value, disabled,

--- a/lib/components/WithEndpoint/util.ts
+++ b/lib/components/WithEndpoint/util.ts
@@ -1,11 +1,10 @@
 import { useMemo, useTransition } from "react";
-import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
+import type { AdapterEndpoint, ParamTree, ParamNode } from "../AdapterEndpoint";
 import { getValueFromPath, isMetadataValue, isParamNode } from "../AdapterEndpoint";
 import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { useError } from "../OdinErrorContext";
 
 import type { ArgType, EndpointProps } from "./utils.types";
-
 
 interface RequestHandler {
     requestHandler: (val?: ParamTree) => void;
@@ -32,7 +31,7 @@ const getLastPathPart = (path: string): [string, string] => {
  * @param endpoint AdapterEndpoint to handle the PUT request
  * @param path Path to the parameter
  */
-async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoint, path: string): Promise<void> {
+async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoint, path: string): Promise<ParamNode> {
 
     const [sendVal, sendPath] = (function () {
         if (isParamNode(val)) {
@@ -49,15 +48,17 @@ async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoin
     try {
         const response = await endpoint.put(sendVal, sendPath);
         endpoint.mergeData(response, sendPath);
+        return response;
     } catch (err) {
         console.debug("Error in PUT occurred in WithEndpoint component", err);
+        return {"error": "PUT Failed"}
     }
 }
 
 function useRequestHandler<PreArgs extends ArgType, PostArgs extends ArgType>(
     { endpoint, fullpath, value, disabled,
-        pre_method, pre_args = [],
-        post_method, post_args = [] }: EndpointProps<PreArgs, PostArgs>
+        pre_method, pre_args,
+        post_method, post_args }: EndpointProps<PreArgs, PostArgs>
 ): RequestHandler {
 
     const [isPending, startTransition] = useTransition();
@@ -166,12 +167,40 @@ function useRequestHandler<PreArgs extends ArgType, PostArgs extends ArgType>(
         try {
             val = validate(val);
             startTransition(async () => {
+                // check if pre_args has the value key, but has set it to undefined
+                // ideally, we'd have a way to check that the PreArgs type has "value"
+                // as a key and see that the pre_args object doesn't include it,
+                // but I need to find a way to make the PreArgs type accessible
+                // at runtime to do that
+                if(pre_args && Object.keys(pre_args).includes("value")) {
+                    if (pre_args.value == undefined || pre_args.value == null) {
+                        // if so, overwrite the value with the param to be put
+                        pre_args.value = val;
+                    }
+                }
+                const modVal = pre_method?.(pre_args as PreArgs);
 
-                pre_method?.(pre_args as PreArgs);
-                // pre_method?.((pre_args ?? {}) as PreArgs);
-
-                sendRequest(val ?? data, endpoint, fullpath)
-                    .then(() => {
+                sendRequest(modVal ?? val ?? data, endpoint, fullpath)
+                    .then((value) => {
+                        
+                        if(post_args && Object.keys(post_args).includes("value")) {
+                            if(post_args.value == undefined || post_args.value == null) {
+                                // depending on Odin Control version, and how
+                                // many Params we are PUTing, the returned response from sendRequest
+                                // can be of of these shapes:
+                                //   {value: param}  - single param, Odin 2.0
+                                //   {[param_name: param]} - single param, Odin 1.6
+                                //   {[param_name]: {param_1: x, param_2: y...}} - multiple param, Odin 1.6
+                                //   {param_1: x, param_2: y...} - multiple param, Odin 2.0
+                                if(Object.keys(value).length == 1){
+                                    // either Odin 1.6 with any number params, or 2.0 with single
+                                    post_args.value = value[Object.keys(value)[0]]
+                                } else {
+                                    // Odin 2.0, multiple params. Set full dict as value
+                                    post_args.value = value;
+                                }
+                            }
+                        }
                         post_method?.(post_args as PostArgs);
                     });
             })

--- a/lib/components/WithEndpoint/util.ts
+++ b/lib/components/WithEndpoint/util.ts
@@ -4,25 +4,8 @@ import { getValueFromPath, isMetadataValue, isParamNode } from "../AdapterEndpoi
 import { MetadataValue } from "../AdapterEndpoint/AdapterEndpoint.types";
 import { useError } from "../OdinErrorContext";
 
+import type { ArgType, EndpointProps } from "./utils.types";
 
-export interface EndpointProps<PreArgs extends unknown[], PostArgs extends unknown[]> {
-    /** Endpoint to connect to */
-    endpoint: AdapterEndpoint;
-    /** Path to the Parameter(s) to control with this component */
-    fullpath: string;
-    /** Optional value to override the value read from the adapter*/
-    value?: ParamTree;
-    /** Disable the component, so it cannot be interacted with*/
-    disabled?: boolean;
-    /** A method to run before performing the PUT request */
-    pre_method?: (...args: PreArgs) => void;
-    /** A method to run after the PUT request succeeds*/
-    post_method?: (...args: PostArgs) => void;
-    /** An array of args to pass to the pre_method*/
-    pre_args?: PreArgs;
-    /** An array of args to pass to the post_method*/
-    post_args?: PostArgs;
-}
 
 interface RequestHandler {
     requestHandler: (val?: ParamTree) => void;
@@ -67,14 +50,14 @@ async function sendRequest<T extends ParamTree>(val: T, endpoint: AdapterEndpoin
         const response = await endpoint.put(sendVal, sendPath);
         endpoint.mergeData(response, sendPath);
     } catch (err) {
-        console.debug("Error in PUT occured in WithEndpoint component", err);
+        console.debug("Error in PUT occurred in WithEndpoint component", err);
     }
 }
 
-function useRequestHandler<PreArgs extends unknown[], PostArgs extends unknown[]>(
+function useRequestHandler<PreArgs extends ArgType, PostArgs extends ArgType>(
     { endpoint, fullpath, value, disabled,
-        pre_method, pre_args,
-        post_method, post_args }: EndpointProps<PreArgs, PostArgs>
+        pre_method, pre_args = [],
+        post_method, post_args = [] }: EndpointProps<PreArgs, PostArgs>
 ): RequestHandler {
 
     const [isPending, startTransition] = useTransition();
@@ -177,16 +160,19 @@ function useRequestHandler<PreArgs extends unknown[], PostArgs extends unknown[]
         return val;
     }
 
+
+
     const requestHandler: RequestHandler["requestHandler"] = (val) => {
         try {
             val = validate(val);
             startTransition(async () => {
 
-                pre_method?.(...(pre_args ?? []) as PreArgs);
+                pre_method?.(pre_args as PreArgs);
+                // pre_method?.((pre_args ?? {}) as PreArgs);
 
                 sendRequest(val ?? data, endpoint, fullpath)
                     .then(() => {
-                        post_method?.(...(post_args ?? []) as PostArgs);
+                        post_method?.(post_args as PostArgs);
                     });
             })
         } catch (err) {
@@ -199,3 +185,4 @@ function useRequestHandler<PreArgs extends unknown[], PostArgs extends unknown[]
 }
 
 export { sendRequest, useRequestHandler };
+export type { EndpointProps, ArgType};

--- a/lib/components/WithEndpoint/utils.types.ts
+++ b/lib/components/WithEndpoint/utils.types.ts
@@ -39,8 +39,29 @@ interface PostMethodNoArgs extends BasicEndpointProps {
 
 export interface EndpointProps<PreArgs extends ArgType, PostArgs extends ArgType>
     extends BasicEndpointProps {
-        pre_method?: (args: PreArgs) => void;
-        pre_args?: PreArgs;
-        post_method?: (args: PostArgs) => void;
-        post_args?: PostArgs;
-    }
+    /** 
+     * A method to run before the PUT request. Accepts a Dictionary of
+     * kwargs. If "value" is one of those keys, the param value will be
+     * inserted into the dictionary.
+     * 
+     * The function can optionally return a value that will be send to
+     * Odin Control.
+    */
+    pre_method?: (args: PreArgs) => void | ParamTree;
+    /** The Dictionary of kwargs to pass to pre_method. To pass the
+     * param value to the method, include a "value" key with a value
+     * that is Null or Undefined.
+     */
+    pre_args?: PreArgs;
+    /**
+     * A method to run after the PUT request succeeds. Accepts a Dictionary of
+     * kwargs. If "value" is one of those keys, the returned param value will be
+     * inserted into the dictionary.
+    */
+    post_method?: (args: PostArgs) => void;
+    /** The Dictionary of kwargs to pass to post_method. To pass the
+    * returned param value to the method, include a "value" key that is Null
+    * or Undefined.
+    */
+    post_args?: PostArgs;
+}

--- a/lib/components/WithEndpoint/utils.types.ts
+++ b/lib/components/WithEndpoint/utils.types.ts
@@ -1,0 +1,46 @@
+import type { AdapterEndpoint, ParamTree } from "../AdapterEndpoint";
+
+export type ArgType = Record<string, unknown> | undefined;
+
+interface BasicEndpointProps {
+    /** Endpoint to connect to */
+    endpoint: AdapterEndpoint;
+    /** Path to the Parameter(s) to control with this component */
+    fullpath: string;
+    /** Optional value to override the value read from the adapter*/
+    value?: ParamTree;
+    /** Disable the component, so it cannot be interacted with*/
+    disabled?: boolean;
+}
+
+interface PreMethodWithArgs<Args extends ArgType> extends BasicEndpointProps {
+    pre_method: (args: Args) => void;
+    pre_args: Args;
+}
+
+interface PreMethodNoArgs extends BasicEndpointProps {
+    pre_method?: () => void;
+    pre_args?: undefined;
+}
+
+interface PostMethodWithArgs<Args extends ArgType> extends BasicEndpointProps {
+    post_method: (args: Args) => void;
+    post_args: Args;
+}
+
+interface PostMethodNoArgs extends BasicEndpointProps {
+    post_method?: () => void;
+    post_args?: undefined;
+}
+
+// export type EndpointProps<PreArgs extends ArgType, PostArgs extends ArgType> =
+//     (PreMethodNoArgs | PreMethodWithArgs<NonNullable<PreArgs>>) &
+//     (PostMethodNoArgs | PostMethodWithArgs<NonNullable<PostArgs>>)
+
+export interface EndpointProps<PreArgs extends ArgType, PostArgs extends ArgType>
+    extends BasicEndpointProps {
+        pre_method?: (args: PreArgs) => void;
+        pre_args?: PreArgs;
+        post_method?: (args: PostArgs) => void;
+        post_args?: PostArgs;
+    }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "odin-react",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "odin-react",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "dependencies": {
                 "axios": "^1.8.1",
                 "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "odin-react",
     "private": true,
-    "version": "2.1.0",
+    "version": "2.1.1",
     "type": "module",
     "main": "./dist/odin-react.umd.cjs.js",
     "module": "./dist/odin-react.js",


### PR DESCRIPTION
Created Endpoint Range Input, an input with a dropdown for multiplying to a specified range (such as Voltage, with options for millivolts).

Added ability for pre/post methods to receive the param value as one of their arguments. This has required reworking the methods to accept a dict of kwargs, rather than a simple array. This is a breaking change for anyone using the pre/post methods.

Additionally, the pre_method can return a value that will be sent via PUT request. the assumption is that the method may want to alter the value before sending to the adapter, such as capitalising a string or changing a numerical value.

Closes #108 
Closes #106 